### PR TITLE
feat: 新增点击播放栏歌手/歌名快捷搜索，并修复 QMenu 组件

### DIFF
--- a/components/QMenu.qml
+++ b/components/QMenu.qml
@@ -25,7 +25,7 @@ Menu {
         implicitHeight: 40
         shadowEffect: true
         blurSource: mainLayout
-        rectXy: Qt.rect(menu.x, menu.y, menu.width, menu.height)
+        rectXy: Qt.rect(dialog.x, dialog.y, dialog.width, dialog.height)
         cardColor: Style.themes.blurSecondaryColor
         borderRadius: Style.settings.labelRadius
     }
@@ -45,10 +45,20 @@ Menu {
                 color: menuItem.down || menuItem.highlighted ? Style.themes.hoverColor : "transparent"
             }
             text: modelData
+            //显式指定contentItem，
+            contentItem: Text {
+                text: menuItem.text
+                color: Style.themes.fontColor//使用项目主题文字色，深浅色主题下都可读
+                font.pixelSize: Style.settings.textmain
+                verticalAlignment: Text.AlignVCenter
+                leftPadding: 12
+                elide: Text.ElideRight//保证超长歌手名不会撑破菜单项
+                clip: true
+            }
             onTriggered: dialog.clicked(index)
         }
-        onObjectAdded: (i, obj) => menu.insertItem(i, obj)
-        onObjectRemoved: (i, obj) => menu.removeItem(obj)
+        onObjectAdded: (i, obj) => dialog.insertItem(i, obj)
+        onObjectRemoved: (i, obj) => dialog.removeItem(obj)
     }
 
 

--- a/layout/PlayerControl.qml
+++ b/layout/PlayerControl.qml
@@ -40,6 +40,29 @@ Rectangle {
         color: Style.themes.sideColor
     }
 
+    // 拆分多歌手，覆盖常见分隔符：/ 、 ， , & ; ；(不含空格，避免拆坏英文歌手名)
+    function parseArtists(raw) {
+        var parts = raw.split(/\s*[\/、,，&;&；]\s*/);
+        var list = [];
+        for(var i = 0; i < parts.length; i++) {
+            var s = parts[i].trim();
+            if(s && list.indexOf(s) === -1) {
+                list.push(s);
+            }
+        }
+        return list;
+    }
+
+    // 统一搜索入口
+    function doSearchSongsMessage(name) {
+        MusicApi.searchSongsResults.clear();
+        mainSearchInput.text = name;
+        MusicApi.nowIndex = 0;
+        mainContent.contentIndexed(6);
+        MusicApi.searchSongs(name, MusicApi.nowIndex, 1, 20);
+        window.exitIndex = 1;
+    }
+
     //控制条
     Item {
         id: sliderControl
@@ -151,8 +174,18 @@ Rectangle {
             font.bold: true
             font.pixelSize: 15
             verticalAlignment: Text.AlignVCenter
-            color: Style.themes.fontColor
+            color: titleDisplayMouse.containsMouse ? Style.themes.themeColor : Style.themes.textColor
 
+            MouseArea {
+                id: titleDisplayMouse
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    if(!window.musicTitle)  return ; 
+                    doSearchSongsMessage(window.musicTitle);
+                }
+            }
         }
         Text {
             id: artistDisplay
@@ -165,7 +198,34 @@ Rectangle {
             font.bold: false
             font.pixelSize: 13
             verticalAlignment: Text.AlignVCenter
-            color: Style.themes.textColor
+            color: artistDisplayMouse.containsMouse ? Style.themes.themeColor : Style.themes.textColor
+
+            MouseArea {
+                id: artistDisplayMouse
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    if(!window.musicArtist)  return ; //本地音乐没有歌手信息时，忽略
+                    var artists = parseArtists(window.musicArtist);
+                    if(artists.length > 1) {
+                        artistMenu.model = artists;// 多歌手,弹菜单
+                        artistMenu.popup();
+                    } 
+                    else {
+                        doSearchSongsMessage(artists[0]);// 单歌手直接搜
+                    }
+
+                }
+            }
+            //多位歌手时，显示菜单
+            QMenu{
+                id: artistMenu
+                model:  []
+                onClicked: (index) => {
+                    doSearchSongsMessage(model[index]);
+                }
+            }
         }
         SButton {
             id: likeButton


### PR DESCRIPTION
#### 背景
- 底部播放栏仅为静态文本，无法通过点击快捷搜索
***
#### 改动
 1. `layout/PlayerControl.qml` —— 点击搜索功能
- 播放栏歌手名（`artistDisplay`）与歌名（`titleDisplay`）支持点击搜索：
  - 悬停高亮 + 🤚形光标提示可点击
  - 单歌手/单歌名直接跳转搜索
  - 多位歌手（按 `/ 、 , ， & ; ；` 分隔）弹出菜单可选择
- 新增 `parseArtists()`：拆分多位歌手并去重、去空白（不包含纯空格——避免拆坏英文歌手名）
- 新增 `doSearchSongsMessage()`：统一搜索入口，复用顶部搜索框
- 本地音乐无歌手信息时点击直接忽略

2. `components/QMenu.qml` — 组件修复
- 修复两处错误引用不存在的 id （`menu` → `dialog`）：
  - background 的 `rectXy` 
  - `Instantiator` 的 `insertItem` 、 `removeItem`
- `MenuItem` 增加显式 `contentItem`：
  - 改用主题文字色 `Style.themes.fontColor`，保证深浅色主题下均可见
  - 超长文本省略号截断，避免撑破菜单项