### PR TITLE
feat: 播放顺序持久化（跨平台）

### DIFF
--- a/components/Options.qml
+++ b/components/Options.qml
@@ -56,6 +56,13 @@ QtObject {
         property bool displayDebugControl //显示控制台
     }
 
+    // 播放器行为设置（跨平台持久化：Windows/macOS/Linux 由 QSettings 写入各自配置目录）
+    property Settings playSettings: Settings {
+        category: "Player"
+        // 播放顺序：0 列表循环，1 单曲循环，2 随机播放，3 顺序播放
+        property int cycleIndex: 0
+    }
+
     // 最后播放的歌曲（关闭软件时保存，下次打开首页显示）
     property Settings lastSongs: Settings {
         category: "LastMedia"

--- a/layout/PlayerControl.qml
+++ b/layout/PlayerControl.qml
@@ -14,8 +14,14 @@ Rectangle {
     color: Style.themes.primaryBlurColor
     clip: false
     property int musicInfoX: 100
-    property int cycleIndex: 0
+    property int cycleIndex: Options.playSettings.cycleIndex
     property int playerRateIndex: 2
+
+    // 播放顺序持久化（跨平台：QSettings → 系统配置目录）
+    onCycleIndexChanged: {
+        if (Options.playSettings.cycleIndex !== cycleIndex)
+            Options.playSettings.cycleIndex = cycleIndex
+    }
 
     readonly property string mediaTime: (Math.floor(mainMedia.position / 60000)) + ":" + (Math.floor(mainMedia.position / 1000) % 60)
     function formatTime(ms) {


### PR DESCRIPTION
## 变更内容

将播放顺序（列表循环 / 单曲循环 / 随机播放 / 顺序播放）改为持久化保存，重启软件后自动恢复上次的播放顺序。

- 在 `Options` 中新增 `Player` 配置分类，使用 Qt `Settings`（底层为 `QSettings`）存储 `cycleIndex`。
- `PlayerControl` 的 `cycleIndex` 初始化时从配置读取，变化时写回配置。

## 跨平台支持

持久化基于 Qt `QSettings` + `QStandardPaths::ConfigLocation`：
- Windows：用户配置目录下的 `BroNekoX/QueMusic.ini`。
- macOS：`~/Library/Preferences` 对应配置。
- Linux：`~/.config` 对应配置。

## 测试

- 切换不同播放顺序后重启，播放顺序保持不变。
- 本地暂无法进行完整 Qt 构建验证，需要在目标平台构建后确认配置写入正常。