### PR TITLE
fix: 修复 Windows SMTC 编译与应用名/进度/切歌；封面暂未正常工作

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,9 +171,10 @@ target_link_libraries(${PROJECT_NAME}
         z
     PUBLIC QWindowKit::Quick
 )
-# Windows SMTC 互操作使用 RoGetActivationFactory / RoActivateInstance，需要 runtimeobject 导入库
+# Windows SMTC 互操作使用 RoGetActivationFactory / RoActivateInstance，需要 runtimeobject 导入库；
+# 应用身份注册（AUMID 快捷方式/注册表）使用 COM 与注册表 API，需要 ole32/shell32/advapi32。
 if(WIN32)
-    target_link_libraries(${PROJECT_NAME} PRIVATE runtimeobject)
+    target_link_libraries(${PROJECT_NAME} PRIVATE runtimeobject ole32 shell32 advapi32)
 endif()
 
 # macOS 上由 macdeployqt 统一部署，避免与 qt_deploy_runtime 冲突

--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ Copyright (c) 2025-2026 QueMusic Contributors
 - [QCloudMusicApi](https://github.com/s12mmm3/QCloudMusicApi) — 使用了本项目api服务，以实现在线音乐网易云音乐平台部分
 - [Cryptopp](https://github.com/weidai11/cryptopp) — 用于QCloudMusicApi解析
 - [libqrencode](https://github.com/weidai11/cryptopp) — 用于QCloudMusicApi
+- [SMTC-Bridge-Cpp](https://github.com/Cainongw/SMTC-Bridge-Cpp) — Windows 系统媒体控件(SMTC)桥接参考实现(C++)
+- [smtc_bridge_rust](https://github.com/Cainongw/smtc_bridge_rust) — Windows 系统媒体控件(SMTC)桥接参考实现(Rust)
 - 以下虽然可能没有使用到他们的代码，但是我仍然致谢他们所带来的精神。
 - [EvolveUI](https://evolveui.top/) — 部分组件设计参考
 - [ShaderToy](https://www.shadertoy.com/) — 着色器灵感来源

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -2185,7 +2185,7 @@ Item {
                 Grid {
                     spacing: 24
                     columns: 2
-                    rows: 3
+                    rows: 4
                     width: settingStack.standWidth
                     AccountCard {
                         source: "qrc:/QueMusic/resources/app/icons/qwk.png"
@@ -2215,6 +2215,18 @@ Item {
                         title: "QCloudMusicApi"
                         text: "网易云音乐第三方API服务框架"
                         openUrl: "https://github.com/s12mmm3/QCloudMusicApi"
+                    }
+                    AccountCard {
+                        source: ""
+                        title: "SMTC-Bridge-Cpp"
+                        text: "Windows 系统媒体控件(SMTC)桥接参考实现(C++)"
+                        openUrl: "https://github.com/Cainongw/SMTC-Bridge-Cpp"
+                    }
+                    AccountCard {
+                        source: ""
+                        title: "smtc_bridge_rust"
+                        text: "Windows 系统媒体控件(SMTC)桥接参考实现(Rust)"
+                        openUrl: "https://github.com/Cainongw/smtc_bridge_rust"
                     }
                 }
 

--- a/cpp/WindowsSmtcManager.cpp
+++ b/cpp/WindowsSmtcManager.cpp
@@ -660,9 +660,9 @@ void WindowsSmtcManager::Private::updateTimeline(qint64 positionMs, qint64 durat
     SmtcAbi::TimeSpan zero;
     zero.Duration = 0;
     SmtcAbi::TimeSpan position;
-    position.Duration = msToTicks(safePosition);
+    position.Duration = SmtcAbi::msToTicks(safePosition);
     SmtcAbi::TimeSpan end;
-    end.Duration = msToTicks(safeDuration);
+    end.Duration = SmtcAbi::msToTicks(safeDuration);
 
     timeline->put_StartTime(zero);
     timeline->put_EndTime(end);
@@ -692,8 +692,8 @@ WindowsSmtcManager::WindowsSmtcManager(QObject *parent)
 WindowsSmtcManager::~WindowsSmtcManager()
 {
 #if QUEMUSIC_SMTC_IMPL
-    if (s_smtcManager == this)
-        s_smtcManager = nullptr;
+    if (SmtcAbi::s_smtcManager == this)
+        SmtcAbi::s_smtcManager = nullptr;
     d->deinit();
 #endif
     delete d;
@@ -714,10 +714,10 @@ void WindowsSmtcManager::initialize(QWindow *window)
         return;
     }
 
-    s_smtcManager = this;
+    SmtcAbi::s_smtcManager = this;
     if (!d->init(window)) {
-        if (s_smtcManager == this)
-            s_smtcManager = nullptr;
+        if (SmtcAbi::s_smtcManager == this)
+            SmtcAbi::s_smtcManager = nullptr;
     }
     emit availableChanged();
 #else
@@ -729,8 +729,8 @@ void WindowsSmtcManager::initialize(QWindow *window)
 void WindowsSmtcManager::shutdown()
 {
 #if QUEMUSIC_SMTC_IMPL
-    if (s_smtcManager == this)
-        s_smtcManager = nullptr;
+    if (SmtcAbi::s_smtcManager == this)
+        SmtcAbi::s_smtcManager = nullptr;
     if (d->initialized)
         d->deinit();
     emit availableChanged();

--- a/cpp/WindowsSmtcManager.cpp
+++ b/cpp/WindowsSmtcManager.cpp
@@ -108,6 +108,11 @@ struct IAutoRepeatModeChangeRequestedEventArgs;
 struct IPlaybackRateChangeRequestedEventArgs;
 struct IShuffleEnabledChangeRequestedEventArgs;
 struct IRandomAccessStreamReference;
+struct IUriRuntimeClass;
+struct IUriRuntimeClassFactory;
+struct IRandomAccessStream;
+struct IRandomAccessStreamWithContentType;
+struct IWwwFormUrlDecoderRuntimeClass;
 struct IVideoDisplayProperties;
 struct IImageDisplayProperties;
 struct IStorageFile;
@@ -136,6 +141,14 @@ static const GUID IID_IMusicDisplayProperties2 = { 0x00368462, 0x97d3, 0x44b9, {
 static const GUID IID_ISystemMediaTransportControlsInterop = { 0xddb0472d, 0xc911, 0x4a1f, { 0x86, 0xd9, 0xdc, 0x3d, 0x71, 0xa9, 0x5f, 0x5a } };
 static const GUID IID_ITypedEventHandler_ButtonPressed = { 0x0557e996, 0x7b23, 0x5bae, { 0xaa, 0x81, 0xea, 0x0d, 0x67, 0x11, 0x43, 0xa4 } };
 static const GUID IID_ITypedEventHandler_PlaybackPosition = { 0x44e34f15, 0xbdc0, 0x50a7, { 0xac, 0xe4, 0x39, 0xe9, 0x1f, 0xb7, 0x53, 0xf1 } };
+// Windows.Storage.Streams.IRandomAccessStreamReference
+static const GUID IID_IRandomAccessStreamReference = { 0x33ee3134, 0x1dd6, 0x4e3a, { 0x80, 0x67, 0xd1, 0xc1, 0x62, 0xe8, 0x64, 0x2b } };
+// Windows.Storage.Streams.IRandomAccessStreamReferenceStatics
+static const GUID IID_IRandomAccessStreamReferenceStatics = { 0x857309dc, 0x3fbf, 0x4e7d, { 0x98, 0x6f, 0xef, 0x3b, 0x1a, 0x07, 0xa9, 0x64 } };
+// Windows.Foundation.IUriRuntimeClass
+static const GUID IID_IUriRuntimeClass = { 0x9e365e57, 0x48b2, 0x4160, { 0x95, 0x6f, 0xc7, 0x38, 0x51, 0x20, 0xbb, 0xfc } };
+// Windows.Foundation.IUriRuntimeClassFactory
+static const GUID IID_IUriRuntimeClassFactory = { 0x44a9796f, 0x723e, 0x4fdf, { 0xa2, 0x18, 0x03, 0x3e, 0x75, 0xb0, 0xc0, 0x84 } };
 
 inline bool guidEquals(const GUID &a, const GUID &b)
 {
@@ -311,6 +324,44 @@ struct ISystemMediaTransportControlsDisplayUpdater : IInspectable {
     virtual HRESULT STDMETHODCALLTYPE Update() = 0;
 };
 
+// Windows.Foundation.Uri（用于把封面 URL 转成 RandomAccessStreamReference）
+struct IUriRuntimeClass : IInspectable {
+    virtual HRESULT STDMETHODCALLTYPE get_AbsoluteUri(HSTRING *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_DisplayUri(HSTRING *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_Domain(HSTRING *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_Extension(HSTRING *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_Fragment(HSTRING *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_Host(HSTRING *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_Password(HSTRING *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_Path(HSTRING *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_Port(INT32 *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_Query(HSTRING *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_QueryParsed(IWwwFormUrlDecoderRuntimeClass **value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_RawUri(HSTRING *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_SchemeName(HSTRING *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_UserName(HSTRING *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE get_Suspicious(boolean *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE Equals(IUriRuntimeClass *pUri, boolean *value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CombineUri(PCWSTR relativeUri, IUriRuntimeClass **value) = 0;
+};
+
+struct IUriRuntimeClassFactory : IInspectable {
+    virtual HRESULT STDMETHODCALLTYPE CreateUri(HSTRING uri, IUriRuntimeClass **value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateWithRelativeUri(HSTRING baseUri, HSTRING relativeUri, IUriRuntimeClass **value) = 0;
+};
+
+// Windows.Storage.Streams.IRandomAccessStreamReference（封面缩略图）
+struct IRandomAccessStreamReference : IInspectable {
+    virtual HRESULT STDMETHODCALLTYPE OpenReadAsync(IAsyncOperation<IRandomAccessStreamWithContentType *> **operation) = 0;
+};
+
+// Windows.Storage.Streams.IRandomAccessStreamReferenceStatics（RandomAccessStreamReference 静态工厂）
+struct IRandomAccessStreamReferenceStatics : IInspectable {
+    virtual HRESULT STDMETHODCALLTYPE CreateFromFile(IStorageFile *file, IRandomAccessStreamReference **value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateFromUri(IUriRuntimeClass *uri, IRandomAccessStreamReference **value) = 0;
+    virtual HRESULT STDMETHODCALLTYPE CreateFromStream(IRandomAccessStream *stream, IRandomAccessStreamReference **value) = 0;
+};
+
 struct IMusicDisplayProperties : IInspectable {
     virtual HRESULT STDMETHODCALLTYPE get_Title(HSTRING *value) = 0;
     virtual HRESULT STDMETHODCALLTYPE put_Title(HSTRING value) = 0;
@@ -427,6 +478,64 @@ public:
     }
 };
 
+// 把封面 URL（http/https/file）转成 RandomAccessStreamReference，
+// 供 DisplayUpdater.Thumbnail 使用。失败或 scheme 不支持时返回空 ComPtr。
+static ComPtr<IRandomAccessStreamReference> createThumbnailFromUrl(const QString &url)
+{
+    ComPtr<IRandomAccessStreamReference> result;
+    if (url.isEmpty())
+        return result;
+
+    const QString trimmed = url.trimmed();
+    if (trimmed.isEmpty())
+        return result;
+
+    // 只处理 SMTC 能真正读取的 scheme（http/https/file）。
+    // qrc:/ 等 Qt 内部 scheme 对 Windows 而言无意义，塞给 SMTC 只会失败。
+    const QString scheme = trimmed.section(QStringLiteral("://"), 0, 0).toLower();
+    if (scheme != QStringLiteral("http") && scheme != QStringLiteral("https")
+        && scheme != QStringLiteral("file")) {
+        return result;
+    }
+
+    // 1) 创建 Windows.Foundation.Uri
+    HStringReference uriClassId(L"Windows.Foundation.Uri");
+    if (!uriClassId.isValid())
+        return result;
+
+    ComPtr<IUriRuntimeClassFactory> uriFactory;
+    HRESULT hr = RoGetActivationFactory(uriClassId.get(), IID_IUriRuntimeClassFactory,
+                                        reinterpret_cast<void **>(uriFactory.put()));
+    if (FAILED(hr) || !uriFactory)
+        return result;
+
+    HString hUri = HString::make(reinterpret_cast<PCWSTR>(trimmed.utf16()),
+                                 UINT32(trimmed.size()));
+    if (!hUri.isValid())
+        return result;
+
+    ComPtr<IUriRuntimeClass> uri;
+    hr = uriFactory->CreateUri(hUri.get(), uri.put());
+    if (FAILED(hr) || !uri)
+        return result;
+
+    // 2) 通过 RandomAccessStreamReference 静态工厂 CreateFromUri
+    HStringReference streamRefClassId(L"Windows.Storage.Streams.RandomAccessStreamReference");
+    if (!streamRefClassId.isValid())
+        return result;
+
+    ComPtr<IRandomAccessStreamReferenceStatics> statics;
+    hr = RoGetActivationFactory(streamRefClassId.get(), IID_IRandomAccessStreamReferenceStatics,
+                                reinterpret_cast<void **>(statics.put()));
+    if (FAILED(hr) || !statics)
+        return result;
+
+    hr = statics->CreateFromUri(uri.get(), result.put());
+    if (FAILED(hr) || !result)
+        result.reset();
+    return result;
+}
+
 } // namespace SmtcAbi
 
 class WindowsSmtcManager::Private
@@ -448,7 +557,8 @@ public:
     void deinit();
     void setControlsEnabled(bool play, bool pause, bool next, bool previous);
     void setPlaybackStatus(int status);
-    void updateMediaInfo(const QString &title, const QString &artist, const QString &album);
+    void updateMediaInfo(const QString &title, const QString &artist, const QString &album,
+                         const QString &cover);
     void updateTimeline(qint64 positionMs, qint64 durationMs);
 };
 
@@ -591,7 +701,8 @@ void WindowsSmtcManager::Private::setPlaybackStatus(int status)
 
 void WindowsSmtcManager::Private::updateMediaInfo(const QString &title,
                                                   const QString &artist,
-                                                  const QString &album)
+                                                  const QString &album,
+                                                  const QString &cover)
 {
     if (!initialized || !displayUpdater)
         return;
@@ -630,6 +741,14 @@ void WindowsSmtcManager::Private::updateMediaInfo(const QString &title,
         }
     }
 
+    // 封面缩略图（专辑封面）：SMTC 弹窗里显示的音乐图标
+    if (!cover.isEmpty()) {
+        SmtcAbi::ComPtr<SmtcAbi::IRandomAccessStreamReference> thumb =
+            SmtcAbi::createThumbnailFromUrl(cover);
+        if (thumb)
+            displayUpdater->put_Thumbnail(thumb.get());
+    }
+
     displayUpdater->Update();
 }
 
@@ -657,10 +776,17 @@ void WindowsSmtcManager::Private::updateTimeline(qint64 positionMs, qint64 durat
     const qint64 safePosition = qMax<qint64>(0, positionMs);
     const qint64 safeDuration = qMax<qint64>(0, durationMs);
 
+    // 时长未知（如直播流或刚切歌的瞬间）时不设置时间线，否则
+    // EndTime=0 / Position>0 会让系统媒体弹窗拒绝显示进度条。
+    if (safeDuration <= 0)
+        return;
+
+    const qint64 clampedPosition = qMin(safePosition, safeDuration);
+
     SmtcAbi::TimeSpan zero;
     zero.Duration = 0;
     SmtcAbi::TimeSpan position;
-    position.Duration = SmtcAbi::msToTicks(safePosition);
+    position.Duration = SmtcAbi::msToTicks(clampedPosition);
     SmtcAbi::TimeSpan end;
     end.Duration = SmtcAbi::msToTicks(safeDuration);
 
@@ -756,12 +882,12 @@ void WindowsSmtcManager::setPlaybackStatus(int status)
 }
 
 void WindowsSmtcManager::updateMediaInfo(const QString &title, const QString &artist,
-                                         const QString &album)
+                                         const QString &album, const QString &cover)
 {
 #if QUEMUSIC_SMTC_IMPL
-    d->updateMediaInfo(title, artist, album);
+    d->updateMediaInfo(title, artist, album, cover);
 #else
-    Q_UNUSED(title); Q_UNUSED(artist); Q_UNUSED(album);
+    Q_UNUSED(title); Q_UNUSED(artist); Q_UNUSED(album); Q_UNUSED(cover);
 #endif
 }
 

--- a/cpp/WindowsSmtcManager.h
+++ b/cpp/WindowsSmtcManager.h
@@ -44,7 +44,8 @@ public:
     Q_INVOKABLE void setControlsEnabled(bool play, bool pause, bool next, bool previous);
     Q_INVOKABLE void setPlaybackStatus(int status);
     Q_INVOKABLE void updateMediaInfo(const QString &title, const QString &artist,
-                                     const QString &album = QString());
+                                     const QString &album = QString(),
+                                     const QString &cover = QString());
     // position/duration 单位为毫秒；每 5 秒调用一次即可，切歌/暂停时也建议调用
     Q_INVOKABLE void updateTimeline(qint64 positionMs, qint64 durationMs);
 

--- a/cpp/WindowsSmtcManager.h
+++ b/cpp/WindowsSmtcManager.h
@@ -6,9 +6,8 @@
 
 #include <QObject>
 #include <QString>
+#include <QWindow>
 #include <QtQmlIntegration/qqmlintegration.h>
-
-class QWindow;
 
 // Windows SMTC（System Media Transport Controls，系统媒体传输控件）管理器。
 // 在 Windows 下启用（MSVC 与 MinGW-w64 均可，直连 WinRT ABI，不依赖 WRL）；

--- a/icon.rc
+++ b/icon.rc
@@ -1,1 +1,36 @@
+#include <windows.h>
+
 IDI_ICON1 ICON "resources/icon.ico"
+
+VS_VERSION_INFO VERSIONINFO
+ FILEVERSION 0,1,0,0
+ PRODUCTVERSION 0,1,0,0
+ FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+ FILEFLAGS 0x1L
+#else
+ FILEFLAGS 0x0L
+#endif
+ FILEOS VOS_NT_WINDOWS32
+ FILETYPE VFT_APP
+ FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "080404b0"
+        BEGIN
+            VALUE "CompanyName", "QueMusic Contributors"
+            VALUE "FileDescription", "QueMusic"
+            VALUE "FileVersion", "0.1.0.0"
+            VALUE "InternalName", "QueMusic"
+            VALUE "LegalCopyright", "Copyright (c) 2026 QueMusic Contributors"
+            VALUE "OriginalFilename", "QueMusic.exe"
+            VALUE "ProductName", "QueMusic"
+            VALUE "ProductVersion", "0.1.0.0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0804, 1200
+    END
+END

--- a/main.cpp
+++ b/main.cpp
@@ -24,8 +24,105 @@ Q_IMPORT_QML_PLUGIN(MeshGradientItemPlugin)
 extern void qml_register_types_QueMusic();
 extern void qml_register_types_MeshGradientItem();
 
+#if defined(Q_OS_WIN)
+// Windows SMTC 弹窗里显示的应用名来自进程的 AppUserModelID（AUMID）。
+// 仅写注册表 DisplayName 只对“通知”有效；媒体弹窗（SMTC）取名的真正来源是
+// 开始菜单里带 AppUserModelID 属性的快捷方式，因此这里同时做三件事：
+//   1) 设置显式 AUMID；2) 注册表 DisplayName/IconUri（供通知等部件）；
+//   3) 创建带 AUMID 的开始菜单快捷方式（SMTC 据此显示应用名/图标）。
+#include <windows.h>
+#include <winreg.h>
+#include <shobjidl.h>
+#include <propsys.h>
+#include <propkey.h>
+#include <string>
+
+static void registerSmtcAppIdentity()
+{
+    const wchar_t *appId = L"BroNekoX.QueMusic";
+
+    // 1) 设置当前进程的显式 AppUserModelID（需在展示任何 UI 之前调用）
+    typedef HRESULT (WINAPI *SetAppUserModelIDFn)(PCWSTR);
+    HMODULE shell32 = LoadLibraryW(L"shell32.dll");
+    if (shell32) {
+        auto fn = reinterpret_cast<SetAppUserModelIDFn>(
+            reinterpret_cast<void *>(GetProcAddress(shell32, "SetCurrentProcessExplicitAppUserModelID")));
+        if (fn)
+            fn(appId);
+    }
+
+    wchar_t exePath[MAX_PATH] = {};
+    GetModuleFileNameW(nullptr, exePath, MAX_PATH);
+
+    // 2) 注册表 DisplayName + IconUri（通知等系统部件解析显示名/图标用）
+    HKEY key = nullptr;
+    if (RegCreateKeyExW(HKEY_CURRENT_USER,
+                        L"Software\\Classes\\AppUserModelId\\BroNekoX.QueMusic",
+                        0, nullptr, 0, KEY_SET_VALUE, nullptr, &key, nullptr) == ERROR_SUCCESS) {
+        const wchar_t *displayName = L"QueMusic";
+        RegSetValueExW(key, L"DisplayName", 0, REG_SZ,
+                       reinterpret_cast<const BYTE *>(displayName),
+                       (DWORD)((wcslen(displayName) + 1) * sizeof(wchar_t)));
+        if (exePath[0]) {
+            // exe 自身带有 .ico 资源，直接指向 exe 即可提取应用图标
+            RegSetValueExW(key, L"IconUri", 0, REG_SZ,
+                           reinterpret_cast<const BYTE *>(exePath),
+                           (DWORD)((wcslen(exePath) + 1) * sizeof(wchar_t)));
+        }
+        RegCloseKey(key);
+    }
+
+    // 3) 创建开始菜单快捷方式并写入 AppUserModelID（SMTC 媒体弹窗取名的关键）
+    HRESULT hr = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
+    const bool comReady = SUCCEEDED(hr); // S_OK / S_FALSE 表示本线程 COM 已就绪
+    if (SUCCEEDED(hr) || hr == RPC_E_CHANGED_MODE) {
+        wchar_t appData[MAX_PATH] = {};
+        if (GetEnvironmentVariableW(L"APPDATA", appData, MAX_PATH)) {
+            const std::wstring lnkPath = std::wstring(appData)
+                + L"\\Microsoft\\Windows\\Start Menu\\Programs\\QueMusic.lnk";
+
+            IShellLinkW *shellLink = nullptr;
+            hr = CoCreateInstance(CLSID_ShellLink, nullptr, CLSCTX_INPROC_SERVER,
+                                  IID_IShellLinkW, reinterpret_cast<void **>(&shellLink));
+            if (SUCCEEDED(hr) && shellLink) {
+                shellLink->SetPath(exePath);
+                shellLink->SetDescription(L"QueMusic");
+                shellLink->SetIconLocation(exePath, 0);
+
+                IPropertyStore *propStore = nullptr;
+                if (SUCCEEDED(shellLink->QueryInterface(IID_IPropertyStore,
+                                                        reinterpret_cast<void **>(&propStore)))
+                    && propStore) {
+                    PROPVARIANT pv;
+                    ZeroMemory(&pv, sizeof(pv));
+                    pv.vt = VT_LPWSTR;
+                    pv.pwszVal = const_cast<wchar_t *>(appId);
+                    propStore->SetValue(PKEY_AppUserModel_ID, pv);
+                    propStore->Commit();
+                    propStore->Release();
+                }
+
+                IPersistFile *persistFile = nullptr;
+                if (SUCCEEDED(shellLink->QueryInterface(IID_IPersistFile,
+                                                        reinterpret_cast<void **>(&persistFile)))
+                    && persistFile) {
+                    persistFile->Save(lnkPath.c_str(), TRUE);
+                    persistFile->Release();
+                }
+                shellLink->Release();
+            }
+        }
+        if (comReady)
+            CoUninitialize();
+    }
+}
+#endif
+
 int main(int argc, char *argv[])
 {
+#if defined(Q_OS_WIN)
+    registerSmtcAppIdentity();
+#endif
     // 从Options.ini读取设置，设置一些高级项喵~
     QString configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
     QSettings opt(configPath + QStringLiteral("/BroNekoX/QueMusic.ini"), QSettings::IniFormat);

--- a/main.qml
+++ b/main.qml
@@ -901,6 +901,14 @@ Window {
                 }
             }
         }
+
+        // 封面就绪后立即推给 SMTC（title/artist 变化时封面可能还是旧值，
+        // 所以必须监听 urlStr 变化单独刷新一次缩略图）
+        onUrlStrChanged: {
+            if (windowsSmtc.available)
+                windowsSmtc.updateMediaInfo(window.musicTitle, window.musicArtist,
+                                            mainMedia.album, urlStr)
+        }
     }
     // Windows SMTC（系统媒体传输控件）：在系统媒体弹窗中显示歌曲信息并可控制播放
     WindowsSmtcManager {
@@ -958,12 +966,12 @@ Window {
         function onMusicTitleChanged() {
             if (windowsSmtc.available)
                 windowsSmtc.updateMediaInfo(window.musicTitle, window.musicArtist,
-                                            mainMedia.album)
+                                            mainMedia.album, mainMedia.urlStr)
         }
         function onMusicArtistChanged() {
             if (windowsSmtc.available)
                 windowsSmtc.updateMediaInfo(window.musicTitle, window.musicArtist,
-                                            mainMedia.album)
+                                            mainMedia.album, mainMedia.urlStr)
         }
     }
 


### PR DESCRIPTION
## 背景
在本地以 QueMusic 官方推荐的 Windows 工具链（Qt 6.9.3 + MinGW 13.1 + Ninja）完整构建时，发现已合入的 SMTC 代码存在编译错误；实测系统媒体弹窗（SMTC）还暴露出应用名显示「未知应用」、进度条、上一首/下一首等运行时问题。

## 修复内容

### 构建修复
- `cpp/WindowsSmtcManager.h`：将 `class QWindow;` 前向声明改为 `#include <QWindow>`，满足 moc 对指针元类型的要求。
- `cpp/WindowsSmtcManager.cpp`：为 `SmtcAbi::msToTicks` / `SmtcAbi::s_smtcManager` 补命名空间限定，修复 `not declared in this scope`。
- `CMakeLists.txt`：Windows 下追加 `ole32` / `shell32` / `advapi32`。

### 弹窗应用名（修复「未知应用」）
- `main.cpp` 启动时：设置显式 `AppUserModelID`、写入 `HKCU\Software\Classes\AppUserModelId\BroNekoX.QueMusic` 的 `DisplayName` / `IconUri`，并创建带 `AppUserModelID` 属性的开始菜单快捷方式。
- 说明：媒体弹窗取应用名的真正来源是开始菜单里带 AUMID 的快捷方式，仅写注册表 / FileDescription 只对通知有效，无法让弹窗正确显示应用名。

### 进度条
- `updateTimeline`：`duration <= 0` 时跳过时间线，并把 `position` 夹到 `[0, duration]`，避免 `EndTime=0` 导致弹窗拒绝显示进度条。

### 上一首 / 下一首
- 已核对 `ITypedEventHandler` 的 IID、按钮枚举值，以及 `ISystemMediaTransportControls2` 的 vtable 顺序，均与 SDK 一致。

### 封面
- 自声明 WinRT ABI：`Windows.Foundation.Uri` 工厂 + `RandomAccessStreamReference.CreateFromUri`，在 `updateMediaInfo` 里设置 `Thumbnail`（支持 http/https/file）。
- `main.qml`：新增 `onUrlStrChanged`，在封面 URL 就绪后单独刷新缩略图，修复此前 title/artist 变化时封面仍是旧值的时序问题。

## 已知问题
- **音乐封面（SMTC 缩略图）暂时仍无法在系统媒体弹窗中显示**。缩略图创建链路（Uri → RandomAccessStreamReference）已独立验证 `S_OK`，但弹窗未呈现封面，后续需继续排查（疑似 SMTC 会话激活 / 缩略图抓取时机）。

## 验证
- MinGW 13.1（mingw1310_64）+ Ninja 全量构建通过，应用可运行。
- 实测：弹窗应用名、进度条、上一首/下一首已工作；封面仍未显示（见「已知问题」）。

## 致谢 / 参考
- 设置页「关于」与 `README.md` 增补了两个 SMTC 桥接参考实现的致谢（仅作实现参考，未作为编译依赖）：
  - [SMTC-Bridge-Cpp](https://github.com/Cainongw/SMTC-Bridge-Cpp)
  - [smtc_bridge_rust](https://github.com/Cainongw/smtc_bridge_rust)