### PR TITLE
feat: 应用日志系统（中文、logs 目录、等级筛选，默认记录错误）

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,8 @@ qt6_add_qml_module(${PROJECT_NAME} # 默认导入项目的
         cpp/CustomFlow.h
         cpp/WindowsSmtcManager.cpp
         cpp/WindowsSmtcManager.h
+        cpp/LogManager.cpp
+        cpp/LogManager.h
         api/MusicApiService.cpp
         api/MusicApiService.h
         api/OnlineListModel.cpp

--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -2479,6 +2479,84 @@ Item {
                         }
                     }
                 }
+
+                QHead { text: "日志" }
+
+                Rectangle {
+                    width: settingStack.standWidth
+                    color: Style.themes.primaryColor
+                    radius: Style.settings.cubeRadius
+                    Column {
+                        width: parent.width
+                        padding: 0
+                        Component.onCompleted: parent.height = height
+
+                        SettingItemCard {
+                            label: "启用日志"
+                            controlItem: QSwitch {
+                                anchors.fill: parent
+                                letRight: true
+                                switchTrue: logManager.enabled
+                                onToggled: logManager.enabled = !logManager.enabled
+                            }
+                        }
+
+                        SettingItemCard {
+                            label: "记录等级"
+                            controlItem: QDrop {
+                                anchors.fill: parent
+                                choice: logManager.minimumLevel
+                                model: ["调试","信息","警告","错误","致命"]
+                                onTransformed: (choiced) => { logManager.minimumLevel = choiced }
+                            }
+                        }
+
+                        SettingItemCard {
+                            label: "打开日志目录"
+                            controlItem: QButton {
+                                anchors.fill: parent
+                                text: "打开"
+                                onClicked: logManager.openLogFolder()
+                            }
+                            bottomLine: false
+                        }
+                    }
+                }
+
+                Rectangle {
+                    width: settingStack.standWidth
+                    height: 200
+                    color: Style.themes.primaryColor
+                    radius: Style.settings.cubeRadius
+                    Column {
+                        anchors.fill: parent
+                        anchors.margins: 16
+                        spacing: 8
+                        Text {
+                            width: parent.width
+                            text: "实时日志预览（完整内容见日志文件）"
+                            color: Style.themes.textColor
+                            font.pixelSize: Style.settings.text
+                        }
+                        Flickable {
+                            id: logPreviewFlick
+                            width: parent.width
+                            height: parent.height - 30
+                            clip: true
+                            contentWidth: width
+                            contentHeight: logPreviewText.height
+                            onContentHeightChanged: contentY = Math.max(0, contentHeight - height)
+                            Text {
+                                id: logPreviewText
+                                width: parent.width
+                                text: logManager.logPreview
+                                color: Style.themes.textColor
+                                font.pixelSize: Style.settings.text
+                                wrapMode: Text.Wrap
+                            }
+                        }
+                    }
+                }
             }
         }
     }

--- a/cpp/LogManager.cpp
+++ b/cpp/LogManager.cpp
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025-2026 QueMusic Contributors
+//
+#include "LogManager.h"
+
+#include <QCoreApplication>
+#include <QDate>
+#include <QDateTime>
+#include <QDesktopServices>
+#include <QDir>
+#include <QFileInfo>
+#include <QStandardPaths>
+#include <QThread>
+#include <QUrl>
+#include <QSettings>
+
+#include <cstdio>
+#include <cstdlib>
+
+std::atomic<LogManager *> LogManager::s_instance{ nullptr };
+
+LogManager::LogManager(QObject *parent)
+    : QObject(parent)
+{
+    // 1) 先注册全局实例指针（消息处理器可能在任何时刻被调用）
+    s_instance.store(this);
+
+    // 2) 确定日志目录：优先“安装目录/logs”；不可写时回退到用户数据目录（多平台健壮性）
+    QString baseDir = QCoreApplication::applicationDirPath() + QStringLiteral("/logs");
+    if (!QDir().mkpath(baseDir)) {
+        baseDir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+                + QStringLiteral("/logs");
+        QDir().mkpath(baseDir);
+    }
+    m_logDir = QDir(baseDir).absolutePath();
+
+    // 3) 读取配置（与 QML Settings 共享同一 ini：configDir + /BroNekoX/QueMusic.ini）
+    {
+        const QString configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+        QSettings settings(configPath + QStringLiteral("/BroNekoX/QueMusic.ini"), QSettings::IniFormat);
+        m_enabled = settings.value(QStringLiteral("Options/logEnabled"), true).toBool();
+        m_minimumLevel = settings.value(QStringLiteral("Options/logLevel"), int(Level::Error)).toInt();
+        m_minimumLevel = qBound(int(Level::Debug), m_minimumLevel, int(Level::Fatal));
+    }
+
+    // 4) 立即创建/打开今天的日志文件并写入会话横幅
+    ensureLogFile();
+
+    // 5) 接管 Qt 全局消息（qDebug/qInfo/qWarning/qCritical/qFatal 都汇聚到这里）
+    qInstallMessageHandler(&LogManager::messageHandler);
+
+    info(QStringLiteral("日志系统已启动"), QStringLiteral("系统"));
+}
+
+LogManager::~LogManager()
+{
+    qInstallMessageHandler(nullptr);
+    s_instance.store(nullptr);
+    if (m_file.isOpen())
+        m_file.close();
+}
+
+bool LogManager::enabled() const
+{
+    return m_enabled;
+}
+
+void LogManager::setEnabled(bool enabled)
+{
+    if (m_enabled == enabled)
+        return;
+    m_enabled = enabled;
+    persistSettings();
+    emit enabledChanged();
+    if (enabled)
+        info(QStringLiteral("日志已启用"), QStringLiteral("系统"));
+}
+
+int LogManager::minimumLevel() const
+{
+    return m_minimumLevel;
+}
+
+void LogManager::setMinimumLevel(int level)
+{
+    level = qBound(int(Level::Debug), level, int(Level::Fatal));
+    if (m_minimumLevel == level)
+        return;
+    m_minimumLevel = level;
+    persistSettings();
+    emit minimumLevelChanged();
+    info(QStringLiteral("记录等级已切换为: %1").arg(levelLabel(level)), QStringLiteral("系统"));
+}
+
+QString LogManager::logDirectory() const
+{
+    return m_logDir;
+}
+
+QString LogManager::currentLogFile() const
+{
+    return m_logFile;
+}
+
+QString LogManager::logPreview() const
+{
+    return m_preview;
+}
+
+void LogManager::debug(const QString &message, const QString &category)
+{
+    writeLine(Level::Debug, category, message);
+}
+
+void LogManager::info(const QString &message, const QString &category)
+{
+    writeLine(Level::Info, category, message);
+}
+
+void LogManager::warning(const QString &message, const QString &category)
+{
+    writeLine(Level::Warning, category, message);
+}
+
+void LogManager::error(const QString &message, const QString &category)
+{
+    writeLine(Level::Error, category, message);
+}
+
+void LogManager::fatal(const QString &message, const QString &category)
+{
+    writeLine(Level::Fatal, category, message);
+}
+
+void LogManager::openLogFolder()
+{
+    QDir().mkpath(m_logDir);
+    QDesktopServices::openUrl(QUrl::fromLocalFile(m_logDir));
+}
+
+void LogManager::writeLine(int level, const QString &category, const QString &message)
+{
+    // 致命错误始终记录；其余级别遵从“启用开关 + 最低等级”筛选
+    if (!m_enabled && level != Level::Fatal)
+        return;
+    if (level < m_minimumLevel)
+        return;
+
+    ensureLogFile();
+    if (!m_file.isOpen())
+        return;
+
+    const QString line = QStringLiteral("[%1] [%2]%3 %4")
+                             .arg(timestamp(),
+                                  levelLabel(level),
+                                  category.isEmpty()
+                                      ? QString()
+                                      : QStringLiteral(" [%1]").arg(category),
+                                  message);
+
+    m_file.write(line.toUtf8());
+    m_file.write("\n");
+    m_file.flush();
+
+    m_recentLines.append(line);
+    constexpr int kMaxPreviewLines = 500;
+    while (m_recentLines.size() > kMaxPreviewLines)
+        m_recentLines.removeFirst();
+    m_preview = m_recentLines.join(QLatin1Char('\n'));
+    emit logPreviewChanged();
+}
+
+void LogManager::ensureLogFile()
+{
+    const QString today = QDate::currentDate().toString(QStringLiteral("yyyyMMdd"));
+    if (m_file.isOpen() && m_dateStamp == today)
+        return;
+
+    if (m_file.isOpen())
+        m_file.close();
+
+    QDir().mkpath(m_logDir);
+    const QString path = m_logDir + QStringLiteral("/QueMusic_") + today + QStringLiteral(".log");
+    m_file.setFileName(path);
+
+    if (m_file.open(QIODevice::WriteOnly | QIODevice::Append)) {
+        m_dateStamp = today;
+        m_logFile = QFileInfo(path).absoluteFilePath();
+
+        // 新文件写入 UTF-8 BOM，便于 Windows 记事本识别中文
+        if (m_file.size() == 0)
+            m_file.write("\xEF\xBB\xBF");
+
+        const QString banner =
+            QStringLiteral("[%1] [信息] [系统] ===== 日志会话开始（记录等级: %2） =====")
+                .arg(timestamp(), levelLabel(m_minimumLevel));
+        m_file.write(banner.toUtf8());
+        m_file.write("\n");
+        m_file.flush();
+
+        if (m_recentLines.isEmpty()) {
+            m_recentLines.append(banner);
+            m_preview = m_recentLines.join(QLatin1Char('\n'));
+            emit logPreviewChanged();
+        }
+    }
+}
+
+void LogManager::persistSettings() const
+{
+    const QString configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
+    QSettings settings(configPath + QStringLiteral("/BroNekoX/QueMusic.ini"), QSettings::IniFormat);
+    settings.setValue(QStringLiteral("Options/logEnabled"), m_enabled);
+    settings.setValue(QStringLiteral("Options/logLevel"), m_minimumLevel);
+}
+
+QString LogManager::levelLabel(int level)
+{
+    switch (level) {
+    case Level::Debug:
+        return QStringLiteral("调试");
+    case Level::Info:
+        return QStringLiteral("信息");
+    case Level::Warning:
+        return QStringLiteral("警告");
+    case Level::Error:
+        return QStringLiteral("错误");
+    case Level::Fatal:
+        return QStringLiteral("致命");
+    }
+    return QStringLiteral("未知");
+}
+
+QString LogManager::timestamp()
+{
+    return QDateTime::currentDateTime().toString(QStringLiteral("yyyy-MM-dd hh:mm:ss.zzz"));
+}
+
+void LogManager::messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg)
+{
+    LogManager *self = s_instance.load();
+
+    // 保留控制台输出（stderr），命令行调试时日志依旧可见
+    const QByteArray localMsg = msg.toLocal8Bit();
+    const char *category = context.category ? context.category : "default";
+    switch (type) {
+    case QtDebugMsg:
+        std::fprintf(stderr, "[调试] %s: %s\n", category, localMsg.constData());
+        break;
+    case QtInfoMsg:
+        std::fprintf(stderr, "[信息] %s: %s\n", category, localMsg.constData());
+        break;
+    case QtWarningMsg:
+        std::fprintf(stderr, "[警告] %s: %s\n", category, localMsg.constData());
+        break;
+    case QtCriticalMsg:
+        std::fprintf(stderr, "[错误] %s: %s\n", category, localMsg.constData());
+        break;
+    case QtFatalMsg:
+        std::fprintf(stderr, "[致命] %s: %s\n", category, localMsg.constData());
+        break;
+    }
+
+    if (!self)
+        return;
+
+    int level = Level::Debug;
+    switch (type) {
+    case QtInfoMsg:
+        level = Level::Info;
+        break;
+    case QtWarningMsg:
+        level = Level::Warning;
+        break;
+    case QtCriticalMsg:
+        level = Level::Error;
+        break;
+    case QtFatalMsg:
+        level = Level::Fatal;
+        break;
+    default:
+        level = Level::Debug;
+        break;
+    }
+
+    const QString cat = QString::fromUtf8(context.category ? context.category : "");
+
+    // 文件写入统一在主线程执行，避免跨线程访问 QFile / QML 预览的竞态
+    if (QThread::currentThread() == self->thread()) {
+        self->writeLine(level, cat, msg);
+    } else {
+        QMetaObject::invokeMethod(self, [self, level, cat, msg]() {
+            self->writeLine(level, cat, msg);
+        }, Qt::QueuedConnection);
+    }
+
+    if (type == QtFatalMsg)
+        std::abort();
+}

--- a/cpp/LogManager.h
+++ b/cpp/LogManager.h
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025-2026 QueMusic Contributors
+//
+#ifndef LOGMANAGER_H
+#define LOGMANAGER_H
+
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QFile>
+#include <QDebug>
+#include <atomic>
+
+// 应用级日志管理器。
+// - 接管 Qt 全局消息（qDebug/qInfo/qWarning/qCritical/qFatal），同时保留控制台输出。
+// - 中文日志，写入“安装目录/logs/QueMusic_yyyyMMdd.log”（每日一个文件，UTF-8）。
+// - 多平台：安装目录不可写时回退到用户数据目录。
+// - 支持分级筛选（默认只记录“错误/致命”），默认开启。
+class LogManager : public QObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(bool enabled READ enabled WRITE setEnabled NOTIFY enabledChanged)
+    Q_PROPERTY(int minimumLevel READ minimumLevel WRITE setMinimumLevel NOTIFY minimumLevelChanged)
+    Q_PROPERTY(QString logDirectory READ logDirectory CONSTANT)
+    Q_PROPERTY(QString currentLogFile READ currentLogFile NOTIFY currentLogFileChanged)
+    Q_PROPERTY(QString logPreview READ logPreview NOTIFY logPreviewChanged)
+
+public:
+    // 与 Qt QtMsgType 严重程度一一对应，供 QML 直接使用
+    enum Level {
+        Debug = 0,
+        Info = 1,
+        Warning = 2,
+        Error = 3,
+        Fatal = 4
+    };
+    Q_ENUM(Level)
+
+    explicit LogManager(QObject *parent = nullptr);
+    ~LogManager() override;
+
+    bool enabled() const;
+    void setEnabled(bool enabled);
+
+    int minimumLevel() const;
+    void setMinimumLevel(int level);
+
+    QString logDirectory() const;
+    QString currentLogFile() const;
+    QString logPreview() const;
+
+    Q_INVOKABLE void debug(const QString &message, const QString &category = QString());
+    Q_INVOKABLE void info(const QString &message, const QString &category = QString());
+    Q_INVOKABLE void warning(const QString &message, const QString &category = QString());
+    Q_INVOKABLE void error(const QString &message, const QString &category = QString());
+    Q_INVOKABLE void fatal(const QString &message, const QString &category = QString());
+    Q_INVOKABLE void openLogFolder();
+
+signals:
+    void enabledChanged();
+    void minimumLevelChanged();
+    void currentLogFileChanged();
+    void logPreviewChanged();
+
+private:
+    static void messageHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg);
+    void writeLine(int level, const QString &category, const QString &message);
+    void ensureLogFile();
+    void persistSettings() const;
+
+    static QString levelLabel(int level);
+    static QString timestamp();
+
+    static std::atomic<LogManager *> s_instance;
+
+    bool m_enabled = true;
+    int m_minimumLevel = Level::Error;   // 默认：错误（问题）
+    QString m_logDir;
+    QString m_logFile;
+    QString m_dateStamp;
+    QFile m_file;
+    QStringList m_recentLines;
+    QString m_preview;
+};
+
+#endif // LOGMANAGER_H

--- a/main.cpp
+++ b/main.cpp
@@ -15,6 +15,7 @@
 #include "cpp/Favorites.h"
 #include "cpp/AccountManager.h"
 #include "api/MusicApiService.h"
+#include "cpp/LogManager.h"
 #include "meshgradient/MeshGradientItem.h"
 #include <QWKQuick/qwkquickglobal.h>
 
@@ -156,6 +157,10 @@ int main(int argc, char *argv[])
 
     QSettings::setDefaultFormat(QSettings::IniFormat);
     QSettings::setPath(QSettings::IniFormat, QSettings::UserScope, configPath);
+
+    // 日志系统：接管 Qt 消息并写入“安装目录/logs”，中文、可分级筛选（默认记录错误及以上）
+    LogManager *logManager = new LogManager(&engine);
+    engine.rootContext()->setContextProperty("logManager", logManager);
 
     // 创建模型实例
     FolderModel *myFolderModel = new FolderModel(&engine);


### PR DESCRIPTION
## 变更内容

新增应用级日志系统（默认开启，位于 设置 → 调试 → 日志）。

- 新增 cpp/LogManager.h/.cpp：接管 Qt 全局消息（qDebug/qInfo/qWarning/qCritical/qFatal），同时保留控制台输出。
- 中文日志，写入 **安装目录/logs**，文件名 QueMusic_yyyyMMdd.log（按天滚动，UTF-8 带 BOM，记事本可直接查看中文）。
- 多平台：安装目录不可写时自动回退到用户数据目录。
- 支持等级筛选：调试/信息/警告/错误/致命，默认 **错误**（问题）；持久化到 Options/logEnabled 与 Options/logLevel。
- 设置页新增"日志"区：启用开关、记录等级下拉、打开日志目录按钮、实时日志预览。
- CMakeLists.txt 注册新源文件；main.cpp 创建并暴露 logManager。

## 测试

- Windows Qt 6.9.3 + MinGW 13.1 + Ninja 全量构建通过。
- 运行时验证：
  - logs 目录与中文日志文件正常生成；
  - 等级切换与开关即时生效；
  - 重启后配置持久化（等级/开关被记忆）。

## 备注

- logs/、*.log 已由 .gitignore 忽略，日志文件不会被误提交。