### PR TITLE
fix:优化SMTC

### DIFF
--- a/cpp/CoverHelper.cpp
+++ b/cpp/CoverHelper.cpp
@@ -6,6 +6,7 @@
 #include <QStandardPaths>
 #include <QFile>
 #include <QDir>
+#include <QFileInfo>
 #include <QUrl>
 
 CoverHelper::CoverHelper(QObject *parent)
@@ -51,6 +52,40 @@ QString CoverHelper::convertVariantToUrl(const QVariant &imageVariant)
 
     m_currentCoverUrl.clear();
     emit currentCoverUrlChanged();
+    return QString();
+}
+
+QString CoverHelper::findLocalCover(const QString &sourcePath)
+{
+    if (sourcePath.isEmpty())
+        return QString();
+
+    QString localPath = sourcePath;
+    const QUrl asUrl(sourcePath);
+    if (asUrl.isLocalFile())
+        localPath = asUrl.toLocalFile();
+
+    const QFileInfo fi(localPath);
+    if (!fi.exists() || !fi.isFile())
+        return QString();
+
+    const QDir dir = fi.absoluteDir();
+    const QString baseName = fi.completeBaseName();
+
+    // 探测顺序：与音频文件同名 -> 常见通用命名（cover/folder/AlbumArt）
+    const QStringList names = { baseName, QStringLiteral("cover"),
+                                QStringLiteral("folder"), QStringLiteral("AlbumArt") };
+    const QStringList extensions = { QStringLiteral("jpg"), QStringLiteral("jpeg"),
+                                     QStringLiteral("png"), QStringLiteral("webp"),
+                                     QStringLiteral("bmp"), QStringLiteral("gif") };
+
+    for (const QString &name : names) {
+        for (const QString &ext : extensions) {
+            const QString candidate = dir.filePath(name + QLatin1Char('.') + ext);
+            if (QFile::exists(candidate))
+                return QUrl::fromLocalFile(candidate).toString();
+        }
+    }
     return QString();
 }
 

--- a/cpp/CoverHelper.h
+++ b/cpp/CoverHelper.h
@@ -20,6 +20,11 @@ public:
     explicit CoverHelper(QObject *parent = nullptr);
 
     Q_INVOKABLE QString convertVariantToUrl(const QVariant &imageVariant);
+    // 元数据未提供内嵌封面时，
+    // 尝试在音频文件同目录查找同名/常见命名的本地封面图片（如 base.jpg/png、cover.jpg/folder.png 等）；
+    // 命中返回 file:// URL，未命中返回空字符串。
+    // sourcePath 为本地文件路径或 file:// URL。
+    Q_INVOKABLE QString findLocalCover(const QString &sourcePath);
     QString currentCoverUrl() const;
     Q_INVOKABLE void clearCache();
 

--- a/cpp/WindowsSmtcManager.cpp
+++ b/cpp/WindowsSmtcManager.cpp
@@ -550,12 +550,17 @@ public:
     SmtcAbi::EventRegistrationToken buttonToken = {};
     SmtcAbi::EventRegistrationToken seekToken = {};
 
+    // 进度节流状态：记录最近一次已推送的 position/duration（ms）。
+    // duration<=0（切歌清空重置）后复位为 -1，使下一条时间线立即推送。
+    qint64 lastTimelinePositionMs = -1;
+    qint64 lastTimelineDurationMs = -1;
+
     bool init(QWindow *window);
     void deinit();
     void setControlsEnabled(bool play, bool pause, bool next, bool previous);
     void setPlaybackStatus(int status);
     void updateMediaInfo(const QString &title, const QString &artist, const QString &album,
-                         const QString &cover);
+                         const QString &cover, const QString &mediaId);
     void updateTimeline(qint64 positionMs, qint64 durationMs);
 };
 
@@ -699,7 +704,8 @@ void WindowsSmtcManager::Private::setPlaybackStatus(int status)
 void WindowsSmtcManager::Private::updateMediaInfo(const QString &title,
                                                   const QString &artist,
                                                   const QString &album,
-                                                  const QString &cover)
+                                                  const QString &cover,
+                                                  const QString &mediaId)
 {
     if (!initialized || !displayUpdater)
         return;
@@ -708,6 +714,15 @@ void WindowsSmtcManager::Private::updateMediaInfo(const QString &title,
     const QString artistStr = artist.isEmpty() ? QStringLiteral("未知歌手") : artist;
 
     displayUpdater->put_Type(SmtcAbi::MediaPlaybackType_Music);
+
+    // AppMediaId：供 SMTC 按曲目区分/分组元信息。mediaId 有值则写入，
+    // 为空时写入空 HSTRING（即清除旧的 id，避免上一首曲目的分组残留）。
+    {
+        SmtcAbi::HString hMediaId = SmtcAbi::HString::make(
+            reinterpret_cast<PCWSTR>(mediaId.utf16()), UINT32(mediaId.size()));
+        if (hMediaId.isValid())
+            displayUpdater->put_AppMediaId(hMediaId.get());
+    }
 
     SmtcAbi::ComPtr<SmtcAbi::IMusicDisplayProperties> musicProps;
     if (FAILED(displayUpdater->get_MusicProperties(musicProps.put())) || !musicProps)
@@ -726,7 +741,8 @@ void WindowsSmtcManager::Private::updateMediaInfo(const QString &title,
             musicProps->put_Artist(hArtist.get());
     }
 
-    if (!album.isEmpty()) {
+    // 专辑名：有值则写入；无值时写入空 HSTRING，清除上一首残留的专辑名。
+    {
         SmtcAbi::ComPtr<SmtcAbi::IMusicDisplayProperties2> musicProps2;
         if (SUCCEEDED(musicProps->QueryInterface(SmtcAbi::IID_IMusicDisplayProperties2,
                                                  reinterpret_cast<void **>(musicProps2.put())))
@@ -738,12 +754,15 @@ void WindowsSmtcManager::Private::updateMediaInfo(const QString &title,
         }
     }
 
-    // 封面缩略图（专辑封面）：SMTC 弹窗里显示的音乐图标
+    // 封面缩略图（专辑封面）：SMTC 弹窗里显示的音乐图标。
+    // 无封面时传空引用清除旧的缩略图，避免残留上一首歌曲封面。
     if (!cover.isEmpty()) {
         SmtcAbi::ComPtr<SmtcAbi::IRandomAccessStreamReference> thumb =
             SmtcAbi::createThumbnailFromUrl(cover);
         if (thumb)
             displayUpdater->put_Thumbnail(thumb.get());
+    } else {
+        displayUpdater->put_Thumbnail(nullptr);
     }
 
     displayUpdater->Update();
@@ -773,12 +792,44 @@ void WindowsSmtcManager::Private::updateTimeline(qint64 positionMs, qint64 durat
     const qint64 safePosition = qMax<qint64>(0, positionMs);
     const qint64 safeDuration = qMax<qint64>(0, durationMs);
 
-    // 时长未知（如直播流或刚切歌的瞬间）时不设置时间线，否则
-    // EndTime=0 / Position>0 会让系统媒体弹窗拒绝显示进度条。
-    if (safeDuration <= 0)
+    // 时长未知（如直播流或刚切歌、duration 尚未加载的瞬间）时，
+    // 用全零 TimelineProperties 重置时间线（而非直接返回），
+    // 避免系统媒体弹窗残留上一首歌曲的进度条；
+    // EndTime=0 时系统不显示进度条。
+    // 此分支不被节流，并复位节流状态，保证切歌瞬间立即清空残留进度。
+    if (safeDuration <= 0) {
+        SmtcAbi::TimeSpan zero;
+        zero.Duration = 0;
+        timeline->put_StartTime(zero);
+        timeline->put_EndTime(zero);
+        timeline->put_MinSeekTime(zero);
+        timeline->put_MaxSeekTime(zero);
+        timeline->put_Position(zero);
+        smtc2->UpdateTimelineProperties(timeline.get());
+        lastTimelinePositionMs = -1;
+        lastTimelineDurationMs = -1;
         return;
+    }
 
     const qint64 clampedPosition = qMin(safePosition, safeDuration);
+
+    // —— 进度节流 ——
+    // position 随播放约 10Hz 变化，
+    // 若每次都重建 TimelineProperties 再调 UpdateTimelineProperties，会高频触发 WinRT 全量重建。
+    // 这里仅在以下任一情况才推送：
+    //  1. 首次推送；
+    //  2. duration 变化（切歌/时长异常，关键事件不节流）；
+    //  3. 进度回退（seek 倒退）；
+    //  4. position 相对上次
+    // 已推送值前进达到阈值。
+    // 其余情况直接跳过本次重建，进度条仍以子系统可接受的频率平滑推进。
+    const qint64 kTimelineThrottleMs = 200;
+    const bool firstPush = (lastTimelineDurationMs < 0);
+    const bool durationChange = (safeDuration != lastTimelineDurationMs);
+    const bool backwardJump = (safePosition < lastTimelinePositionMs);
+    if (!firstPush && !durationChange && !backwardJump
+        && (safePosition - lastTimelinePositionMs) < kTimelineThrottleMs)
+        return;
 
     SmtcAbi::TimeSpan zero;
     zero.Duration = 0;
@@ -794,6 +845,9 @@ void WindowsSmtcManager::Private::updateTimeline(qint64 positionMs, qint64 durat
     timeline->put_Position(position);
 
     smtc2->UpdateTimelineProperties(timeline.get());
+
+    lastTimelineDurationMs = safeDuration;
+    lastTimelinePositionMs = clampedPosition;
 }
 
 #else // QUEMUSIC_SMTC_IMPL
@@ -879,12 +933,13 @@ void WindowsSmtcManager::setPlaybackStatus(int status)
 }
 
 void WindowsSmtcManager::updateMediaInfo(const QString &title, const QString &artist,
-                                         const QString &album, const QString &cover)
+                                         const QString &album, const QString &cover,
+                                         const QString &mediaId)
 {
 #if QUEMUSIC_SMTC_IMPL
-    d->updateMediaInfo(title, artist, album, cover);
+    d->updateMediaInfo(title, artist, album, cover, mediaId);
 #else
-    Q_UNUSED(title); Q_UNUSED(artist); Q_UNUSED(album); Q_UNUSED(cover);
+    Q_UNUSED(title); Q_UNUSED(artist); Q_UNUSED(album); Q_UNUSED(cover); Q_UNUSED(mediaId);
 #endif
 }
 

--- a/cpp/WindowsSmtcManager.h
+++ b/cpp/WindowsSmtcManager.h
@@ -45,7 +45,8 @@ public:
     Q_INVOKABLE void setPlaybackStatus(int status);
     Q_INVOKABLE void updateMediaInfo(const QString &title, const QString &artist,
                                      const QString &album = QString(),
-                                     const QString &cover = QString());
+                                     const QString &cover = QString(),
+                                     const QString &mediaId = QString());
     // position/duration 单位为毫秒；每 5 秒调用一次即可，切歌/暂停时也建议调用
     Q_INVOKABLE void updateTimeline(qint64 positionMs, qint64 durationMs);
 

--- a/layout/PlayerControl.qml
+++ b/layout/PlayerControl.qml
@@ -556,6 +556,10 @@ Rectangle {
         if(playListModel.playListIndex > 0) {
             playListModel.playListIndex -= 1;
             musicControlMin.refreshMusicPlay();
+            if(windowsSmtc.available)
+                windowsSmtc.setControlsEnabled(true, true,
+                    playListModel.playListIndex < playListModel.count - 1,
+                    playListModel.playListIndex > 0);
         }
     }
     // 下一首
@@ -566,11 +570,19 @@ Rectangle {
             playListModel.playListIndex = 0;
         }
         musicControlMin.refreshMusicPlay();
+        if(windowsSmtc.available)
+            windowsSmtc.setControlsEnabled(true, true,
+                playListModel.playListIndex < playListModel.count - 1,
+                playListModel.playListIndex > 0);
     }
     // 随机播放音乐
     function randomMedia() {
         playListModel.playListIndex = Math.floor( Math.random() * playListModel.count );
         musicControlMin.refreshMusicPlay();
+        if(windowsSmtc.available)
+            windowsSmtc.setControlsEnabled(true, true,
+                playListModel.playListIndex < playListModel.count - 1,
+                playListModel.playListIndex > 0);
     }
     // 切换播放列表显示
     function togglePlayList() {

--- a/main.qml
+++ b/main.qml
@@ -904,7 +904,10 @@ Window {
                     console.log("封面艺术url: " + urlStr);
                     colorExtractor.extractColorsFromUrl(urlStr);
                 } else {
-                    urlStr = null
+                    // 元数据未内嵌封面：本地文件尝试同目录同名/常见命名封面图兜底
+                    // （如 a.mp3 旁的 a.jpg / cover.png）。未命中则保持空，与原行为一致。
+                    var localCover = coverHelper.findLocalCover(mainMedia.source)
+                    urlStr = localCover ? localCover : null
                 }
 
 
@@ -935,16 +938,42 @@ Window {
 
         onUrlStrChanged: {
             if (windowsSmtc.available)
-                windowsSmtc.updateMediaInfo(window.musicTitle, window.musicArtist,
-                                            mainMedia.album, urlStr)
+                smtcUpdateMediaInfo()
         }
     }
+    // 依据播放列表上下文动态启用/禁用 SMTC 的上一首/下一首按钮
+    // （无上一首/下一首时禁用对应按钮，避免一律恒启用）
+    function updateSmtcControls() {
+        if (!windowsSmtc.available)
+            return;
+        var count = playListModel.count;
+        var idx = playListModel.playListIndex;
+        windowsSmtc.setControlsEnabled(true, true, idx < count - 1, idx > 0);
+    }
+
+    // 统一将当前曲目信息推给 SMTC。
+    // AppMediaId 取播放列表当前项的稳定标识 path（在线歌曲为歌曲 hash、本地文件为文件路径），供系统按曲目分组元信息；
+    // 列表未就绪/无当前项时传空串，C++ 侧会清除旧的 id。
+    function smtcUpdateMediaInfo() {
+        if (!windowsSmtc.available)
+            return
+        var mediaId = ""
+        if (playListModel.count > 0 && playListModel.playListIndex >= 0) {
+            var item = playListModel.get(playListModel.playListIndex)
+            if (item)
+                mediaId = item.path
+        }
+        windowsSmtc.updateMediaInfo(window.musicTitle, window.musicArtist,
+                                    mainMedia.album, mainMedia.urlStr, mediaId)
+    }
+
     // Windows SMTC
     WindowsSmtcManager {
         id: windowsSmtc
 
         Component.onCompleted: {
             windowsSmtc.initialize(window);
+            updateSmtcControls()
         }
     }
 
@@ -961,7 +990,21 @@ Window {
     Connections {
         target: mainMedia
 
+        function onSourceChanged() {
+            // 切歌/新曲目开始播放的瞬间：主动推送 position=0 并刷新时间线；
+            // duration 尚未就绪（<=0）时由 C++ 侧走全零重置分支清空上一首的残留进度。
+            if (windowsSmtc.available)
+                windowsSmtc.updateTimeline(0, mainMedia.duration)
+            updateSmtcControls()
+        }
+        function onDurationChanged() {
+            // 新歌时长加载完成：以 position=0 主动推送一条完整时间线，
+            // 随后 onPositionChanged 会用实时位置持续刷新。
+            if (windowsSmtc.available && mainMedia.duration > 0)
+                windowsSmtc.updateTimeline(0, mainMedia.duration)
+        }
         function onPlaybackStateChanged() {
+            updateSmtcControls()
             if (!windowsSmtc.available)
                 return
             switch (mainMedia.playbackState) {
@@ -993,13 +1036,11 @@ Window {
 
         function onMusicTitleChanged() {
             if (windowsSmtc.available)
-                windowsSmtc.updateMediaInfo(window.musicTitle, window.musicArtist,
-                                            mainMedia.album, mainMedia.urlStr)
+                smtcUpdateMediaInfo()
         }
         function onMusicArtistChanged() {
             if (windowsSmtc.available)
-                windowsSmtc.updateMediaInfo(window.musicTitle, window.musicArtist,
-                                            mainMedia.album, mainMedia.urlStr)
+                smtcUpdateMediaInfo()
         }
     }
 
@@ -1007,6 +1048,8 @@ Window {
     ListModel {
         id: playListModel
         property int playListIndex: -1
+        // 列表增删后同步 SMTC 上一首/下一首按钮可用性
+        onCountChanged: updateSmtcControls()
     }
     SearchCard {
         id: searchCard


### PR DESCRIPTION
### 概述
增强 Windows SMTC 

### 修复内容
- **切歌时间线残留**：切歌时主动 `updateTimeline()`；duration 未就绪前清空旧时间线，不再残留上一首的封面/进度
- **高频刷新失控**：进度刷新线程增加节流（阈值 200ms），避免 10Hz 无节流刷屏
- **控制按钮恒启用**：根据是否存在上一首/下一首动态启用/禁用 SMTC 按钮
- **AppMediaId 未设置**：补充 AppMediaId，Windows 会话更稳定
- **封面/专辑空值不清理**：空值、无效封面路径主动置空并兜底本地封面
  （`findLocalCover`）
- **联动完善**：`onSourceChanged` / `onDurationChanged` 触发信息与时间线刷新，
  歌词/窗口换歌同步更新 SMTC
