### PR TITLE
feat: support local embedded lyrics (#12)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "api/QCloudMusicApi/3rdparty/cryptopp"]
 	path = api/QCloudMusicApi/3rdparty/cryptopp
 	url = https://github.com/weidai11/cryptopp.git
+[submodule "ThirdParty/taglib"]
+	path = ThirdParty/taglib
+	url = https://github.com/taglib/taglib.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,18 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O2")
 
 add_subdirectory(cmake)
 find_package(Qt6 REQUIRED COMPONENTS Core Gui Qml Quick Network Multimedia Concurrent Sql ShaderTools)
+
+# TagLib is vendored so local metadata parsing works consistently on all
+# supported platforms without requiring a system package.
+set(BUILD_BINDINGS OFF CACHE BOOL "" FORCE)
+set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+# qwindowkit may set BUILD_SHARED_LIBS globally. Keep TagLib static so the
+# application bundle does not require a separately deployed libtag dylib.
+set(_quemusic_build_shared_libs ${BUILD_SHARED_LIBS})
+set(BUILD_SHARED_LIBS OFF)
+add_subdirectory(ThirdParty/taglib ${CMAKE_BINARY_DIR}/_deps/taglib-build EXCLUDE_FROM_ALL)
+set(BUILD_SHARED_LIBS ${_quemusic_build_shared_libs})
+unset(_quemusic_build_shared_libs)
 #add_subdirectory(api)
 #include_directories(api)
 
@@ -30,6 +42,11 @@ qt_add_executable(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/api
+    ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/taglib/taglib
+    ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/taglib/taglib/toolkit
+    ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/taglib/taglib/mpeg
+    ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/taglib/taglib/mpeg/id3v2
+    ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/taglib/taglib/mpeg/id3v2/frames
 )
 
 # 按平台设置应用类型：Windows 用 GUI 子系统，macOS 生成 .app bundle
@@ -123,6 +140,8 @@ qt6_add_qml_module(${PROJECT_NAME} # 默认导入项目的
         cpp/Favorites.h
         cpp/AccountManager.cpp
         cpp/AccountManager.h
+        cpp/LocalLyricsReader.cpp
+        cpp/LocalLyricsReader.h
         cpp/CustomFlow.cpp
         cpp/CustomFlow.h
         cpp/WindowsSmtcManager.cpp
@@ -170,6 +189,7 @@ target_link_libraries(${PROJECT_NAME}
         Qt6::Multimedia
         Qt6::Concurrent
         QCloudMusicApi
+        tag
         cryptopp::cryptopp
         quemusic_meshgradientplugin
         z
@@ -185,3 +205,24 @@ endif()
 if(NOT APPLE)
     qt_deploy_runtime(${PROJECT_NAME})
 endif()
+
+enable_testing()
+find_package(Qt6 REQUIRED COMPONENTS Test)
+add_executable(quemusic_local_lyrics_test
+    tests/local_lyrics_reader_test.cpp
+    cpp/LocalLyricsReader.cpp
+)
+target_include_directories(quemusic_local_lyrics_test PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/taglib/taglib
+    ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/taglib/taglib/toolkit
+    ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/taglib/taglib/mpeg
+    ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/taglib/taglib/mpeg/id3v2
+    ${CMAKE_CURRENT_SOURCE_DIR}/ThirdParty/taglib/taglib/mpeg/id3v2/frames
+)
+target_link_libraries(quemusic_local_lyrics_test PRIVATE
+    Qt6::Core
+    Qt6::Test
+    tag
+)
+add_test(NAME quemusic_local_lyrics_test COMMAND quemusic_local_lyrics_test)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,12 @@
 | **🛡️ 可靠性高** | 自制 JS API 管理层，统一错误处理，速度快且持续优化 |
 | **💻 跨平台** | 全面支持 **Windows / macOS / Linux** 三大桌面端 |
 
+### 本地歌词加载
+
+本地歌曲按以下顺序读取歌词：同目录同名 `.lrc` → 音频内嵌歌词 → 在线匹配 → “纯音乐，请欣赏”占位。
+内嵌歌词支持 ID3v2 的同步歌词（SYLT）与非同步歌词（USLT），以及 TagLib 能识别的
+`LYRICS` 文本元数据（常见于 FLAC、Ogg/Opus、MP4/M4A 等格式）。
+
 ---
 
 ## 🖼️ 截图预览
@@ -118,7 +124,7 @@ git clone --recurse-submodules https://github.com/BroNekoX/QueMusic.git
 cd QueMusic
 ```
 
-> ⚠️ **重要**：本项目使用 QWindowKit 作为 git 子模块，务必加上 `--recurse-submodules`。
+> ⚠️ **重要**：本项目使用 QWindowKit、TagLib 作为 git 子模块，务必加上 `--recurse-submodules`。
 > 如果已经 clone 但忘记拉子模块，运行：
 > 
 > ```bash
@@ -217,6 +223,7 @@ QueMusic/
 │   ├── GetWave.cpp/h           # 音频波形数据
 │   ├── FolderModel.cpp/h       # 本地文件夹模型
 │   ├── DownloadManager.cpp/h   # 下载管理器
+│   ├── LocalLyricsReader.cpp/h # .lrc 与音频内嵌歌词读取
 │   └── Favorites.cpp/h         # 收藏管理
 ├── meshgradient/               # 🧩 独立 Mesh Gradient 背景组件（AGPL-3.0）
 │   ├── CMakeLists.txt          # 独立库 target：quemusic_meshgradient
@@ -394,4 +401,3 @@ QueMusic 官方版本始终保持开源与永久免费，没有任何Pro、Ultra
   <sub>Written by QueMusic Project</sub><br/>
   <sub>最后更新：2026-8-26</sub>
 </p>
-

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -78,4 +78,5 @@ QueMusic 其余代码 Apache-2.0**，二者互不影响。
 （如后续引入其他第三方组件，请在此处补充声明。）
 
 - **QWindowKit**：窗口标题栏 / 系统集成组件，遵循其自身许可证（见其项目文档）。
+- **TagLib 2.3.1**：本地音频元数据与 ID3v2 歌词读取，采用 LGPL-2.1-or-later / MPL-1.1 双许可证；源码与许可证位于 `ThirdParty/taglib/`。
 - **图标字体**（`feather.ttf`、`poppins.ttf` 等）：仅作资源使用，版权归原作者所有。

--- a/api/MusicApiService.cpp
+++ b/api/MusicApiService.cpp
@@ -13,6 +13,7 @@
 #include <QUrl>
 
 #include "../cpp/AccountManager.h"
+#include "../cpp/LocalLyricsReader.h"
 
 namespace {
 constexpr int kSourceKugou = 0;
@@ -236,6 +237,36 @@ void MusicApiService::setLocalLyrics()
     setLyricsTranslate(QVariantList()); // 清空翻译，避免残留
 }
 
+QVariantMap MusicApiService::readLocalLyrics(const QString &filePath)
+{
+    return LocalLyricsReader::read(filePath);
+}
+
+void MusicApiService::findLocalLyrics(const QString &filePath, const QString &title,
+                                      const QString &artist, int duration, int source)
+{
+    const int resolvedSource = resolve(source);
+    const QString cleanTitle = title.trimmed();
+    if (filePath.trimmed().isEmpty() || cleanTitle.isEmpty()) {
+        emit localLyricsFailed(filePath);
+        return;
+    }
+
+    LocalLyricsRequest request;
+    request.filePath = filePath;
+    request.title = cleanTitle;
+    request.artist = artist.trimmed();
+    request.duration = duration;
+    m_localLyricsSearches.insert(resolvedSource, request);
+
+    // Search only songs so the result can be resolved to a hash and then sent
+    // through the existing platform-specific lyric endpoint.
+    const QString keyword = request.artist.isEmpty()
+        ? request.title
+        : request.title + QLatin1Char(' ') + request.artist;
+    searchSongs(keyword, 0, 1, 10, resolvedSource);
+}
+
 // 读取本地音频同目录同名 .json 元数据；不存在返回空 map
 QVariantMap MusicApiService::readLocalMetadata(const QString &filePath)
 {
@@ -402,7 +433,43 @@ void MusicApiService::handleResult(const QString &action, const QVariant &data, 
                               : data;
 
     if (action == QLatin1String("searchSongs")) {
-        m_searchSongsResults.append(normalizeList(info));
+        if (m_localLyricsSearches.contains(source)) {
+            const LocalLyricsRequest request = m_localLyricsSearches.take(source);
+            const QVariantList songs = normalizeList(info);
+            QVariantMap best;
+            int bestScore = -1;
+            for (const QVariant &value : songs) {
+                const QVariantMap candidate = value.toMap();
+                const QString candidateTitle = candidate.value(QStringLiteral("title")).toString();
+                const QString candidateArtist = candidate.value(QStringLiteral("artist")).toString();
+                int score = 0;
+                if (candidateTitle.compare(request.title, Qt::CaseInsensitive) == 0)
+                    score += 4;
+                else if (candidateTitle.contains(request.title, Qt::CaseInsensitive)
+                         || request.title.contains(candidateTitle, Qt::CaseInsensitive))
+                    score += 2;
+                if (!request.artist.isEmpty()
+                    && (candidateArtist.contains(request.artist, Qt::CaseInsensitive)
+                        || request.artist.contains(candidateArtist, Qt::CaseInsensitive)))
+                    score += 2;
+                if (!candidate.value(QStringLiteral("hash")).toString().isEmpty())
+                    score += 1;
+                if (score > bestScore) {
+                    bestScore = score;
+                    best = candidate;
+                }
+            }
+
+            const QString hash = best.value(QStringLiteral("hash")).toString();
+            if (hash.isEmpty()) {
+                emit localLyricsFailed(request.filePath);
+            } else {
+                m_pendingLocalLyrics.insert(hash, request);
+                getLyricInfo(hash, request.duration, source);
+            }
+        } else {
+            m_searchSongsResults.append(normalizeList(info));
+        }
     } else if (action == QLatin1String("getPlaylistMenu")) {
         // 歌单分类：map 数组（QML 侧 text: modelData.title / [i].id 访问）
         QVariantList menu;
@@ -488,8 +555,18 @@ void MusicApiService::handleResult(const QString &action, const QVariant &data, 
         setLyricsData(d.value(QStringLiteral("info")));
         setLyricsTranslate(d.value(QStringLiteral("translate")));
 
+        const QString lyricHash = d.value(QStringLiteral("hash")).toString();
+        if (!lyricHash.isEmpty() && m_pendingLocalLyrics.contains(lyricHash)) {
+            const LocalLyricsRequest request = m_pendingLocalLyrics.take(lyricHash);
+            const QVariantList lyrics = d.value(QStringLiteral("info")).toList();
+            if (lyrics.isEmpty())
+                emit localLyricsFailed(request.filePath);
+            else
+                emit localLyricsReady(request.filePath, lyrics);
+        }
+
         // 歌词返回后发起下载
-        const QString hash = d.value(QStringLiteral("hash")).toString();
+        const QString hash = lyricHash;
         if (!hash.isEmpty() && m_pendingDownloads.contains(hash)) {
             QVariantMap meta = m_pendingDownloads.take(hash);
             meta.insert(QStringLiteral("lyrics"), d.value(QStringLiteral("info")));

--- a/api/MusicApiService.h
+++ b/api/MusicApiService.h
@@ -141,6 +141,12 @@ public:
     Q_INVOKABLE void setLocalLyrics();
     // 读取本地音频同目录同名 .json 元数据（不存在返回空 map）
     Q_INVOKABLE QVariantMap readLocalMetadata(const QString &filePath);
+    // 读取本地歌词：同名 .lrc 优先，其次读取音频内嵌歌词。
+    Q_INVOKABLE QVariantMap readLocalLyrics(const QString &filePath);
+    // 本地歌词不存在时，按标题/歌手搜索在线歌词；结果通过信号返回。
+    Q_INVOKABLE void findLocalLyrics(const QString &filePath, const QString &title,
+                                     const QString &artist, int duration = 0,
+                                     int source = -1);
 
 signals:
     void loaded();   // loadState 置 true（QLoadSign 显示加载动画）
@@ -159,6 +165,8 @@ signals:
     void globalinfoChanged();
     void nowIndexChanged();
     void downloadPathChanged();
+    void localLyricsReady(const QString &filePath, const QVariantList &lyrics);
+    void localLyricsFailed(const QString &filePath);
 
 private slots:
     void handleResult(const QString &action, const QVariant &data, int source);
@@ -169,6 +177,13 @@ private:
     QVariantMap normalizeItem(const QVariantMap &raw); // 字段归一化 + 旧字段别名
     QVariantList normalizeList(const QVariant &v);
     void handleMusicInfo(const QVariantMap &d, int source);
+
+    struct LocalLyricsRequest {
+        QString filePath;
+        QString title;
+        QString artist;
+        int duration = 0;
+    };
 
     int m_source = 0;
     NeteaseCloudApi m_netease;   // 网易云（源 1）：基于 QCloudMusicApi（weapi 加密协议）
@@ -196,6 +211,8 @@ private:
 
     // 下载流程：按 hash 暂存待下载元数据，等歌词返回后一起发起下载
     QMap<QString, QVariantMap> m_pendingDownloads;
+    QMap<int, LocalLyricsRequest> m_localLyricsSearches;
+    QMap<QString, LocalLyricsRequest> m_pendingLocalLyrics;
 
     bool m_loadState = false;
     QVariant m_globalid;

--- a/cpp/LocalLyricsReader.cpp
+++ b/cpp/LocalLyricsReader.cpp
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 QueMusic Contributors
+//
+#include "LocalLyricsReader.h"
+
+#include <QFile>
+#include <QFileInfo>
+#include <QRegularExpression>
+#include <QUrl>
+
+#include <algorithm>
+
+#include <fileref.h>
+#include <mpegfile.h>
+#include <id3v2tag.h>
+#include <synchronizedlyricsframe.h>
+#include <unsynchronizedlyricsframe.h>
+#include <tpropertymap.h>
+
+namespace {
+
+QString tagString(const TagLib::String &value)
+{
+    return QString::fromUtf8(value.toCString(true));
+}
+
+QVariantMap lyricLine(qint64 time, const QString &text)
+{
+    QVariantMap line;
+    line.insert(QStringLiteral("time"), time);
+    line.insert(QStringLiteral("text"), text);
+    return line;
+}
+
+QString localFilePath(const QString &filePath)
+{
+    const QString fromUrl = QUrl::fromUserInput(filePath).toLocalFile();
+    return fromUrl.isEmpty() ? filePath : fromUrl;
+}
+
+} // namespace
+
+QVariantList LocalLyricsReader::parseLrc(const QString &contents)
+{
+    static const QRegularExpression timestamp(
+        QStringLiteral(R"(\[(\d{1,3}):(\d{2})(?:\.(\d{1,3}))?\])"));
+
+    QVariantList lyrics;
+    const QString normalized = contents.startsWith(QChar(0xFEFF))
+        ? contents.mid(1)
+        : contents;
+    const QStringList lines = normalized.split(QRegularExpression(QStringLiteral("[\\r\\n]")),
+                                               Qt::KeepEmptyParts);
+
+    for (const QString &line : lines) {
+        QRegularExpressionMatchIterator matches = timestamp.globalMatch(line);
+        QString text = line;
+        bool hasTimestamp = false;
+        QList<qint64> times;
+        while (matches.hasNext()) {
+            const QRegularExpressionMatch match = matches.next();
+            hasTimestamp = true;
+            const qint64 minutes = match.captured(1).toLongLong();
+            const qint64 seconds = match.captured(2).toLongLong();
+            QString fraction = match.captured(3);
+            while (fraction.size() < 3)
+                fraction.append(QLatin1Char('0'));
+            const qint64 milliseconds = fraction.isEmpty() ? 0 : fraction.left(3).toLongLong();
+            times.append((minutes * 60 + seconds) * 1000 + milliseconds);
+        }
+
+        if (!hasTimestamp)
+            continue;
+        text.remove(timestamp);
+        text = text.trimmed();
+        if (text.isEmpty())
+            continue;
+        for (const qint64 time : times)
+            lyrics.append(lyricLine(time, text));
+    }
+
+    std::stable_sort(lyrics.begin(), lyrics.end(), [](const QVariant &left, const QVariant &right) {
+        return left.toMap().value(QStringLiteral("time")).toLongLong()
+             < right.toMap().value(QStringLiteral("time")).toLongLong();
+    });
+    return lyrics;
+}
+
+QVariantList LocalLyricsReader::parsePlainLyrics(const QString &text)
+{
+    const QString cleaned = text.trimmed();
+    if (cleaned.isEmpty())
+        return {};
+
+    // USLT and generic LYRICS tags are unsynchronized. Keep the complete text
+    // in one item so the player can display it without pretending timestamps.
+    return {lyricLine(0, cleaned)};
+}
+
+QVariantList LocalLyricsReader::parseEmbeddedLyrics(const QString &filePath)
+{
+    const QByteArray encodedPath = QFile::encodeName(filePath);
+    if (encodedPath.isEmpty())
+        return {};
+
+    TagLib::FileRef ref(encodedPath.constData(), false);
+    if (ref.isNull() || ref.file() == nullptr)
+        return {};
+
+    // SYLT is the native ID3v2 synchronized-lyrics frame. Only millisecond
+    // timestamps can be mapped to the playback position without extra data.
+    if (auto *mpeg = dynamic_cast<TagLib::MPEG::File *>(ref.file())) {
+        if (auto *id3v2 = mpeg->ID3v2Tag()) {
+            const auto synchronized = id3v2->frameList("SYLT");
+            for (auto *frame : synchronized) {
+                auto *sylt = dynamic_cast<TagLib::ID3v2::SynchronizedLyricsFrame *>(frame);
+                if (!sylt || sylt->timestampFormat()
+                    != TagLib::ID3v2::SynchronizedLyricsFrame::AbsoluteMilliseconds)
+                    continue;
+
+                QVariantList lyrics;
+                for (const auto &entry : sylt->synchedText()) {
+                    const QString text = tagString(entry.text).trimmed();
+                    if (!text.isEmpty())
+                        lyrics.append(lyricLine(entry.time, text));
+                }
+                if (!lyrics.isEmpty())
+                    return lyrics;
+            }
+
+            const auto unsynchronized = id3v2->frameList("USLT");
+            for (auto *frame : unsynchronized) {
+                auto *uslt = dynamic_cast<TagLib::ID3v2::UnsynchronizedLyricsFrame *>(frame);
+                if (!uslt)
+                    continue;
+                const QString text = tagString(uslt->text());
+                const QVariantList timed = parseLrc(text);
+                if (!timed.isEmpty())
+                    return timed;
+                const QVariantList plain = parsePlainLyrics(text);
+                if (!plain.isEmpty())
+                    return plain;
+            }
+        }
+    }
+
+    // TagLib exposes Vorbis/FLAC, MP4, ASF and other text metadata through the
+    // common property map. This also covers ID3v2 LYRICS properties not selected
+    // by the frame-specific path above.
+    const TagLib::PropertyMap properties = ref.properties();
+    for (auto it = properties.cbegin(); it != properties.cend(); ++it) {
+        const QString key = tagString(it->first).toUpper();
+        if (!key.startsWith(QStringLiteral("LYRICS")))
+            continue;
+        const QString text = tagString(it->second.toString("")).trimmed();
+        if (text.isEmpty())
+            continue;
+        const QVariantList timed = parseLrc(text);
+        return timed.isEmpty() ? parsePlainLyrics(text) : timed;
+    }
+    return {};
+}
+
+QVariantMap LocalLyricsReader::result(const QString &source, const QVariantList &lyrics)
+{
+    QVariantMap value;
+    value.insert(QStringLiteral("found"), !lyrics.isEmpty());
+    value.insert(QStringLiteral("source"), source);
+    value.insert(QStringLiteral("lyrics"), lyrics);
+    return value;
+}
+
+QVariantMap LocalLyricsReader::read(const QString &filePath)
+{
+    const QString localPath = localFilePath(filePath);
+    if (localPath.isEmpty())
+        return result(QStringLiteral("none"), {});
+
+    const QFileInfo audioInfo(localPath);
+    const QString sidecarPath = audioInfo.absolutePath() + QLatin1Char('/')
+                              + audioInfo.completeBaseName() + QStringLiteral(".lrc");
+    QFile sidecar(sidecarPath);
+    if (sidecar.open(QIODevice::ReadOnly)) {
+        const QVariantList lyrics = parseLrc(QString::fromUtf8(sidecar.readAll()));
+        if (!lyrics.isEmpty())
+            return result(QStringLiteral("sidecar"), lyrics);
+    }
+
+    const QVariantList embedded = parseEmbeddedLyrics(localPath);
+    if (!embedded.isEmpty())
+        return result(QStringLiteral("embedded"), embedded);
+    return result(QStringLiteral("none"), {});
+}

--- a/cpp/LocalLyricsReader.h
+++ b/cpp/LocalLyricsReader.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 QueMusic Contributors
+//
+#ifndef LOCALLYRICSREADER_H
+#define LOCALLYRICSREADER_H
+
+#include <QVariantList>
+#include <QVariantMap>
+
+class LocalLyricsReader
+{
+public:
+    // Parse standard LRC timestamps into the lyric model used by PlayerMaxCenter.
+    static QVariantList parseLrc(const QString &contents);
+
+    // Read an audio file's sidecar LRC first, then embedded metadata lyrics.
+    // The result contains: found (bool), source (sidecar/embedded), lyrics (list).
+    static QVariantMap read(const QString &filePath);
+
+private:
+    static QVariantList parseEmbeddedLyrics(const QString &filePath);
+    static QVariantList parsePlainLyrics(const QString &text);
+    static QVariantMap result(const QString &source, const QVariantList &lyrics);
+};
+
+#endif // LOCALLYRICSREADER_H

--- a/main.qml
+++ b/main.qml
@@ -54,23 +54,52 @@ Window {
     property string version: "Beta-0.4.1"
     property int versionCode: 41
 
-    // 播放本地歌曲：有同名 .json 用其元数据，否则回退内嵌标签
+    property string localLyricsRequestPath: ""
+
+    Connections {
+        target: MusicApi
+        function onLocalLyricsReady(filePath, lyrics) {
+            if (filePath !== window.localLyricsRequestPath)
+                return;
+            MusicApi.lyricsData = lyrics;
+            MusicApi.lyricsTranslate = [];
+        }
+        function onLocalLyricsFailed(filePath) {
+            if (filePath !== window.localLyricsRequestPath)
+                return;
+            MusicApi.setLocalLyrics();
+        }
+    }
+
+    // 播放本地歌曲：同名 .lrc → 内嵌歌词 → 在线匹配 → 占位歌词
     function playLocalSong(path, name) {
         var meta = MusicApi.readLocalMetadata(path) || {};
         var hasMeta = Object.keys(meta).length > 0;
+        var localLyrics = MusicApi.readLocalLyrics(path) || {};
+        var hasLocalLyrics = localLyrics.found === true && localLyrics.lyrics && localLyrics.lyrics.length > 0;
+        var title = meta.title || name;
+        var artist = meta.artist || "";
+        window.localLyricsRequestPath = path;
         if (hasMeta) {
             mainMedia.urlLocal = false;
-            mainMedia.noTitle = meta.title || name;
+            mainMedia.noTitle = title;
             mainMedia.urlStr = meta.cover || "qrc:/QueMusic/resources/app/musicpic.png";
-            window.musicTitle = meta.title || name;
-            window.musicArtist = meta.artist || "";
-            MusicApi.lyricsData = meta.lyrics || [];
-            MusicApi.lyricsTranslate = meta.translate || [];
+            window.musicTitle = title;
+            window.musicArtist = artist;
+            MusicApi.lyricsData = hasLocalLyrics ? localLyrics.lyrics : (meta.lyrics || []);
+            MusicApi.lyricsTranslate = hasLocalLyrics ? [] : (meta.translate || []);
             colorExtractor.extractColorsFromUrl(meta.cover);
         } else {
             mainMedia.urlLocal = true;
             mainMedia.noTitle = name;
+            window.musicTitle = name;
+            window.musicArtist = "";
+            MusicApi.lyricsData = hasLocalLyrics ? localLyrics.lyrics : [];
+            MusicApi.lyricsTranslate = [];
+        }
+        if (!hasLocalLyrics && (!hasMeta || !meta.lyrics || meta.lyrics.length === 0)) {
             MusicApi.setLocalLyrics();
+            MusicApi.findLocalLyrics(path, title, artist, meta.duration || 0);
         }
         mainMedia.source = path;
         mainMedia.play();

--- a/tests/local_lyrics_reader_test.cpp
+++ b/tests/local_lyrics_reader_test.cpp
@@ -1,0 +1,109 @@
+#include <QtTest>
+
+#include "LocalLyricsReader.h"
+
+class LocalLyricsReaderTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    void parsesLrcTimestampsAndSorts();
+    void readsSidecarBeforeEmbeddedLyrics();
+    void readsEmbeddedId3LyricsWhenSidecarIsMissing();
+};
+
+static QByteArray syncSafeSize(int size)
+{
+    QByteArray encoded(4, '\0');
+    encoded[0] = char((size >> 21) & 0x7f);
+    encoded[1] = char((size >> 14) & 0x7f);
+    encoded[2] = char((size >> 7) & 0x7f);
+    encoded[3] = char(size & 0x7f);
+    return encoded;
+}
+
+static QByteArray id3v23Uslt(const QByteArray &text)
+{
+    QByteArray payload;
+    payload.append(char(0));             // ISO-8859-1 text encoding
+    payload.append("eng", 3);
+    payload.append(char(0));             // empty description
+    payload.append(text);
+
+    QByteArray frame("USLT", 4);
+    frame.append(char((payload.size() >> 24) & 0xff));
+    frame.append(char((payload.size() >> 16) & 0xff));
+    frame.append(char((payload.size() >> 8) & 0xff));
+    frame.append(char(payload.size() & 0xff));
+    frame.append("\0\0", 2);
+    frame.append(payload);
+
+    QByteArray id3("ID3", 3);
+    id3.append(char(3));
+    id3.append(char(0));
+    id3.append(char(0));
+    id3.append(syncSafeSize(frame.size()));
+    id3.append(frame);
+    return id3;
+}
+
+void LocalLyricsReaderTest::parsesLrcTimestampsAndSorts()
+{
+    const QVariantList lyrics = LocalLyricsReader::parseLrc(
+        QStringLiteral("[ar:测试]\n[00:03.50]晚一点\n[00:01.2][00:02.00]前奏\n"));
+
+    QCOMPARE(lyrics.size(), 3);
+    QCOMPARE(lyrics.at(0).toMap().value(QStringLiteral("time")).toLongLong(), 1200LL);
+    QCOMPARE(lyrics.at(1).toMap().value(QStringLiteral("time")).toLongLong(), 2000LL);
+    QCOMPARE(lyrics.at(2).toMap().value(QStringLiteral("time")).toLongLong(), 3500LL);
+    QCOMPARE(lyrics.at(0).toMap().value(QStringLiteral("text")).toString(), QStringLiteral("前奏"));
+}
+
+void LocalLyricsReaderTest::readsSidecarBeforeEmbeddedLyrics()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+
+    const QString audioPath = dir.filePath(QStringLiteral("song.mp3"));
+    QFile audio(audioPath);
+    QVERIFY(audio.open(QIODevice::WriteOnly));
+    const QByteArray embedded = id3v23Uslt("[00:02.00]embedded");
+    QVERIFY(audio.write(embedded) == embedded.size());
+    audio.close();
+
+    QFile lrc(dir.filePath(QStringLiteral("song.lrc")));
+    QVERIFY(lrc.open(QIODevice::WriteOnly | QIODevice::Text));
+    QVERIFY(lrc.write("[00:01.00]sidecar\n") > 0);
+    lrc.close();
+
+    const QVariantMap result = LocalLyricsReader::read(audioPath);
+    QCOMPARE(result.value(QStringLiteral("source")).toString(), QStringLiteral("sidecar"));
+    QCOMPARE(result.value(QStringLiteral("found")).toBool(), true);
+    const QVariantList lyrics = result.value(QStringLiteral("lyrics")).toList();
+    QCOMPARE(lyrics.size(), 1);
+    QCOMPARE(lyrics.first().toMap().value(QStringLiteral("text")).toString(), QStringLiteral("sidecar"));
+}
+
+void LocalLyricsReaderTest::readsEmbeddedId3LyricsWhenSidecarIsMissing()
+{
+    QTemporaryDir dir;
+    QVERIFY(dir.isValid());
+    const QString audioPath = dir.filePath(QStringLiteral("embedded.mp3"));
+
+    QFile audio(audioPath);
+    QVERIFY(audio.open(QIODevice::WriteOnly));
+    const QByteArray id3 = id3v23Uslt("[00:02.00]embedded");
+    QVERIFY(audio.write(id3) == id3.size());
+    audio.close();
+
+    const QVariantMap result = LocalLyricsReader::read(audioPath);
+    QCOMPARE(result.value(QStringLiteral("source")).toString(), QStringLiteral("embedded"));
+    QCOMPARE(result.value(QStringLiteral("found")).toBool(), true);
+    const QVariantList lyrics = result.value(QStringLiteral("lyrics")).toList();
+    QCOMPARE(lyrics.size(), 1);
+    QCOMPARE(lyrics.first().toMap().value(QStringLiteral("time")).toLongLong(), 2000LL);
+    QCOMPARE(lyrics.first().toMap().value(QStringLiteral("text")).toString(), QStringLiteral("embedded"));
+}
+
+QTEST_MAIN(LocalLyricsReaderTest)
+#include "local_lyrics_reader_test.moc"


### PR DESCRIPTION
## Summary

Closes #12

This PR adds local lyrics support for local music files.

## Changes

- Support same-name `.lrc` sidecar lyrics files.
- Support embedded lyrics in audio files:
  - ID3v2 `SYLT` synchronized lyrics
  - ID3v2 `USLT` unsynchronized lyrics
  - `LYRICS` metadata in FLAC, Ogg/Opus, MP4/M4A and other TagLib-supported formats
- Add TagLib as a submodule dependency.
- Add online lyric search fallback when local lyrics are unavailable.
- Keep the existing fallback behavior for songs without lyrics.
- Add QtTest coverage for LRC parsing, sidecar lyrics, and embedded ID3 lyrics.
- Update build configuration and documentation.

## Lyrics Loading Priority

1. Same-name `.lrc` file
2. Embedded lyrics in the audio file
3. Existing local metadata lyrics
4. Online lyric search
5. Placeholder lyrics

## Testing

- macOS build completed successfully.
- QtTest result: `1/1 tests passed`.
- Tested LRC timestamp parsing and sorting.
- Tested sidecar lyrics priority.
- Tested embedded ID3v2 lyrics parsing.

## Notes

The QWindowKit submodule contains unrelated local changes and was not included in this PR.