### PR TITLE
feat: 本地歌词逐字支持（增强LRC/KRC风格/SYLT）

### DIFF
--- a/cpp/LocalLyricsReader.cpp
+++ b/cpp/LocalLyricsReader.cpp
@@ -29,6 +29,9 @@ QVariantMap lyricLine(qint64 time, const QString &text)
     QVariantMap line;
     line.insert(QStringLiteral("time"), time);
     line.insert(QStringLiteral("text"), text);
+    // 在线歌词的数据契约：无逐字信息时 info 为 null，有逐字时是
+    // [{offset, duration, text}]。这里保持一致，避免 QML 侧做额外判断。
+    line.insert(QStringLiteral("info"), QVariant());
     return line;
 }
 
@@ -37,6 +40,84 @@ QString localFilePath(const QString &filePath)
     const QString fromUrl = QUrl::fromUserInput(filePath).toLocalFile();
     return fromUrl.isEmpty() ? filePath : fromUrl;
 }
+
+// 毫秒小数：LRC 允许 1~3 位小数，统一补齐到 3 位再截取，避免 0.5 被读成 5ms。
+qint64 threeDigitFraction(const QString &fraction)
+{
+    QString value = fraction;
+    while (value.size() < 3)
+        value.append(QLatin1Char('0'));
+    return value.left(3).toLongLong();
+}
+
+// 字级标签沿用在线歌词的两种写法：
+//   1) 增强 LRC：<mm:ss[.f]>，时间是相对整首歌的绝对位置
+//   2) KRC 风格：<offset,duration,flag>，offset/duration 相对所在行
+struct TimedWord
+{
+    bool relative = false;
+    qint64 absoluteTime = 0;
+    qint64 offset = 0;
+    qint64 duration = 0;
+    QString text;
+};
+
+struct WordLabels
+{
+    QList<TimedWord> words;
+    QString leading; // 第一个字级标签之前未标注的文本（增强 LRC 常见）
+};
+
+QString withoutWordLabels(const QString &contents);
+
+WordLabels extractWordLabels(const QString &contents)
+{
+    static const QRegularExpression re(QStringLiteral(
+        R"(<(?:(?:(\d{1,3}):(\d{2})(?:\.(\d{1,3}))?)|(?:(\d+),(\d+),\d+))>([^<]*))"));
+
+    WordLabels labels;
+    int firstStart = -1;
+    QRegularExpressionMatchIterator it = re.globalMatch(contents);
+    while (it.hasNext()) {
+        const QRegularExpressionMatch match = it.next();
+        TimedWord word;
+        word.text = match.captured(6);
+        if (word.text.isEmpty())
+            continue;
+        if (firstStart < 0)
+            firstStart = match.capturedStart(0);
+        if (!match.captured(4).isEmpty()) {
+            word.relative = true;
+            word.offset = match.captured(4).toLongLong();
+            word.duration = match.captured(5).toLongLong();
+        } else {
+            word.absoluteTime = match.captured(1).toLongLong() * 60000
+                              + match.captured(2).toLongLong() * 1000
+                              + threeDigitFraction(match.captured(3));
+        }
+        labels.words.append(word);
+    }
+    if (firstStart > 0)
+        labels.leading = withoutWordLabels(contents.left(firstStart));
+    return labels;
+}
+
+QString withoutWordLabels(const QString &contents)
+{
+    static const QRegularExpression re(QStringLiteral(
+        R"(<(?:(?:(?:\d{1,3}):(?:\d{2})(?:\.\d{1,3})?)|(?:\d+,\d+,\d+))>)"));
+    QString plain = contents;
+    plain.remove(re);
+    return plain.trimmed();
+}
+
+struct WordEntry
+{
+    qint64 effective = 0; // 合成到整首歌坐标后的时间，便于统一算 offset/duration
+    bool hasExplicitDuration = false;
+    qint64 explicitDuration = 0;
+    QString text;
+};
 
 } // namespace
 
@@ -62,21 +143,83 @@ QVariantList LocalLyricsReader::parseLrc(const QString &contents)
             hasTimestamp = true;
             const qint64 minutes = match.captured(1).toLongLong();
             const qint64 seconds = match.captured(2).toLongLong();
-            QString fraction = match.captured(3);
-            while (fraction.size() < 3)
-                fraction.append(QLatin1Char('0'));
-            const qint64 milliseconds = fraction.isEmpty() ? 0 : fraction.left(3).toLongLong();
-            times.append((minutes * 60 + seconds) * 1000 + milliseconds);
+            times.append((minutes * 60 + seconds) * 1000
+                         + threeDigitFraction(match.captured(3)));
         }
 
         if (!hasTimestamp)
             continue;
         text.remove(timestamp);
-        text = text.trimmed();
-        if (text.isEmpty())
+        const WordLabels labels = extractWordLabels(text);
+        const QString plainText = withoutWordLabels(text);
+        if (plainText.isEmpty())
             continue;
-        for (const qint64 time : times)
-            lyrics.append(lyricLine(time, text));
+        const bool isOther = plainText.startsWith(QStringLiteral("（"))
+                           && plainText.endsWith(QStringLiteral("）"));
+
+        for (const qint64 time : times) {
+            // 没有字级标签的普通行：info 保持 null，走原来的整行高亮
+            if (labels.words.isEmpty() && labels.leading.isEmpty()) {
+                lyrics.append(lyricLine(time, plainText));
+                continue;
+            }
+
+            QList<WordEntry> entries;
+            if (!labels.leading.isEmpty()) {
+                WordEntry leadingEntry;
+                leadingEntry.effective = time;
+                leadingEntry.text = labels.leading;
+                entries.append(leadingEntry);
+            }
+            for (const TimedWord &word : labels.words) {
+                WordEntry entry;
+                if (word.relative) {
+                    entry.effective = time + word.offset;
+                    entry.hasExplicitDuration = true;
+                    entry.explicitDuration = word.duration;
+                } else {
+                    entry.effective = word.absoluteTime;
+                }
+                entry.text = word.text;
+                entries.append(entry);
+            }
+
+            QVariantList info;
+            QString fullText;
+            qint64 previousDuration = 0;
+            for (int i = 0; i < entries.size(); ++i) {
+                const WordEntry &entry = entries.at(i);
+                QString wordText = entry.text;
+                if (isOther) {
+                    wordText.remove(QStringLiteral("（"));
+                    wordText.remove(QStringLiteral("）"));
+                }
+
+                const qint64 offset = qMax<qint64>(0, entry.effective - time);
+                qint64 duration = 0;
+                if (entry.hasExplicitDuration) {
+                    duration = entry.explicitDuration; // KRC 风格沿用在线逐字时长
+                } else if (i + 1 < entries.size()) {
+                    duration = qMax<qint64>(0, entries.at(i + 1).effective - entry.effective);
+                } else {
+                    duration = i > 0 ? previousDuration : 0; // 行尾字沿用上一字时长
+                }
+
+                QVariantMap word;
+                word.insert(QStringLiteral("offset"), offset);
+                word.insert(QStringLiteral("duration"), duration);
+                word.insert(QStringLiteral("text"), wordText);
+                info.append(word);
+                fullText += wordText;
+                previousDuration = duration;
+            }
+
+            QVariantMap item = lyricLine(time, fullText);
+            item.insert(QStringLiteral("info"), info);
+            if (isOther)
+                item.insert(QStringLiteral("isOther"), true);
+            lyrics.append(item);
+        }
     }
 
     std::stable_sort(lyrics.begin(), lyrics.end(), [](const QVariant &left, const QVariant &right) {
@@ -92,8 +235,8 @@ QVariantList LocalLyricsReader::parsePlainLyrics(const QString &text)
     if (cleaned.isEmpty())
         return {};
 
-    // USLT and generic LYRICS tags are unsynchronized. Keep the complete text
-    // in one item so the player can display it without pretending timestamps.
+    // USLT 与通用 LYRICS 标签没有时间轴，保留完整文本为一整行，
+    // 播放器按无语义时间显示，不伪装出时间戳。
     return {lyricLine(0, cleaned)};
 }
 
@@ -107,8 +250,8 @@ QVariantList LocalLyricsReader::parseEmbeddedLyrics(const QString &filePath)
     if (ref.isNull() || ref.file() == nullptr)
         return {};
 
-    // SYLT is the native ID3v2 synchronized-lyrics frame. Only millisecond
-    // timestamps can be mapped to the playback position without extra data.
+    // SYLT 是 ID3v2 的原生同步歌词帧，时间戳为绝对毫秒。每一条目本身
+    // 就是一个音节/词，直接映射成在线歌词的字级 info 结构。
     if (auto *mpeg = dynamic_cast<TagLib::MPEG::File *>(ref.file())) {
         if (auto *id3v2 = mpeg->ID3v2Tag()) {
             const auto synchronized = id3v2->frameList("SYLT");
@@ -118,14 +261,31 @@ QVariantList LocalLyricsReader::parseEmbeddedLyrics(const QString &filePath)
                     != TagLib::ID3v2::SynchronizedLyricsFrame::AbsoluteMilliseconds)
                     continue;
 
-                QVariantList lyrics;
-                for (const auto &entry : sylt->synchedText()) {
-                    const QString text = tagString(entry.text).trimmed();
-                    if (!text.isEmpty())
-                        lyrics.append(lyricLine(entry.time, text));
+                const auto entries = sylt->synchedText();
+                const int count = static_cast<int>(entries.size());
+                if (count > 0) {
+                    QVariantList lyrics;
+                    for (int i = 0; i < count; ++i) {
+                        const QString text = tagString(entries[i].text).trimmed();
+                        if (text.isEmpty())
+                            continue;
+                        const qint64 time = entries[i].time;
+                        const qint64 nextTime = i + 1 < count ? entries[i + 1].time : time;
+
+                        QVariantMap line = lyricLine(time, text);
+                        QVariantList words;
+                        QVariantMap word;
+                        word.insert(QStringLiteral("offset"), QVariant::fromValue<qint64>(0));
+                        word.insert(QStringLiteral("duration"),
+                                    qMax<qint64>(0, nextTime - time));
+                        word.insert(QStringLiteral("text"), text);
+                        words.append(word);
+                        line.insert(QStringLiteral("info"), words);
+                        lyrics.append(line);
+                    }
+                    if (!lyrics.isEmpty())
+                        return lyrics;
                 }
-                if (!lyrics.isEmpty())
-                    return lyrics;
             }
 
             const auto unsynchronized = id3v2->frameList("USLT");

--- a/cpp/LocalLyricsReader.h
+++ b/cpp/LocalLyricsReader.h
@@ -10,7 +10,8 @@
 class LocalLyricsReader
 {
 public:
-    // Parse standard LRC timestamps into the lyric model used by PlayerMaxCenter.
+    // Parse LRC (standard line timestamps + enhanced word-level timestamps)
+    // into the lyric model used by PlayerMaxCenter.
     static QVariantList parseLrc(const QString &contents);
 
     // Read an audio file's sidecar LRC first, then embedded metadata lyrics.

--- a/layout/PlayerMaxCenter.qml
+++ b/layout/PlayerMaxCenter.qml
@@ -394,7 +394,7 @@ Item {
                     lyricContent.finalH = 0;
                     fixedAnime.running = true;
                 }
-                if(MusicApi.lyricsData[idx].info) {
+                if(MusicApi.lyricsData[idx].info && idx + 1 < MusicApi.lyricsData.length) {
                     var lyricLastLineData = MusicApi.lyricsData[idx].info[MusicApi.lyricsData[idx].info.length - 1];
                     if(MusicApi.lyricsData[idx + 1].time - MusicApi.lyricsData[idx].time - lyricLastLineData.offset - lyricLastLineData.duration > 2500 && mainMedia.position > MusicApi.lyricsData[idx].time + lyricLastLineData.offset + lyricLastLineData.duration) {
                         if(!waitAnimeSection.visible) {

--- a/tests/local_lyrics_reader_test.cpp
+++ b/tests/local_lyrics_reader_test.cpp
@@ -8,6 +8,8 @@ class LocalLyricsReaderTest : public QObject
 
 private slots:
     void parsesLrcTimestampsAndSorts();
+    void parsesEnhancedLrcWordTimings();
+    void stripsEmptyWordLabelsFromText();
     void readsSidecarBeforeEmbeddedLyrics();
     void readsEmbeddedId3LyricsWhenSidecarIsMissing();
 };
@@ -57,6 +59,65 @@ void LocalLyricsReaderTest::parsesLrcTimestampsAndSorts()
     QCOMPARE(lyrics.at(1).toMap().value(QStringLiteral("time")).toLongLong(), 2000LL);
     QCOMPARE(lyrics.at(2).toMap().value(QStringLiteral("time")).toLongLong(), 3500LL);
     QCOMPARE(lyrics.at(0).toMap().value(QStringLiteral("text")).toString(), QStringLiteral("前奏"));
+}
+
+void LocalLyricsReaderTest::parsesEnhancedLrcWordTimings()
+{
+    const QVariantList lyrics = LocalLyricsReader::parseLrc(
+        QStringLiteral("[00:10.00]<00:10.00>我 <00:10.50>爱 <00:11.00>你\n"
+                       "[00:12.00]结尾\n"
+                       "[00:14.00]<0,300,0>起 <300,400,0>风\n"));
+
+    QCOMPARE(lyrics.size(), 3);
+
+    // 增强 LRC：绝对字级时间 → 相对本行的 offset/duration，行尾字沿用上一字时长
+    const QVariantMap enhanced = lyrics.at(0).toMap();
+    QCOMPARE(enhanced.value(QStringLiteral("time")).toLongLong(), 10000LL);
+    QCOMPARE(enhanced.value(QStringLiteral("text")).toString(), QStringLiteral("我 爱 你"));
+    const QVariantList info = enhanced.value(QStringLiteral("info")).toList();
+    QCOMPARE(info.size(), 3);
+    QCOMPARE(info.at(0).toMap().value(QStringLiteral("offset")).toLongLong(), 0LL);
+    QCOMPARE(info.at(1).toMap().value(QStringLiteral("offset")).toLongLong(), 500LL);
+    QCOMPARE(info.at(2).toMap().value(QStringLiteral("offset")).toLongLong(), 1000LL);
+    QCOMPARE(info.at(0).toMap().value(QStringLiteral("duration")).toLongLong(), 500LL);
+    QCOMPARE(info.at(1).toMap().value(QStringLiteral("duration")).toLongLong(), 500LL);
+    QCOMPARE(info.at(2).toMap().value(QStringLiteral("duration")).toLongLong(), 500LL);
+
+    // 无字级标签的普通行保持 null info，走整行高亮
+    const QVariantMap plain = lyrics.at(1).toMap();
+    QCOMPARE(plain.value(QStringLiteral("text")).toString(), QStringLiteral("结尾"));
+    QVERIFY(!plain.value(QStringLiteral("info")).isValid());
+
+    // KRC 风格相对字级标签，沿用在线逐字解析
+    const QVariantMap krcStyle = lyrics.at(2).toMap();
+    QCOMPARE(krcStyle.value(QStringLiteral("time")).toLongLong(), 14000LL);
+    QCOMPARE(krcStyle.value(QStringLiteral("text")).toString(), QStringLiteral("起 风"));
+    const QVariantList krcInfo = krcStyle.value(QStringLiteral("info")).toList();
+    QCOMPARE(krcInfo.at(0).toMap().value(QStringLiteral("offset")).toLongLong(), 0LL);
+    QCOMPARE(krcInfo.at(0).toMap().value(QStringLiteral("duration")).toLongLong(), 300LL);
+    QCOMPARE(krcInfo.at(1).toMap().value(QStringLiteral("offset")).toLongLong(), 300LL);
+    QCOMPARE(krcInfo.at(1).toMap().value(QStringLiteral("duration")).toLongLong(), 400LL);
+}
+
+void LocalLyricsReaderTest::stripsEmptyWordLabelsFromText()
+{
+    const QVariantList lyrics = LocalLyricsReader::parseLrc(
+        QStringLiteral("[00:09.00]前言<00:00.000>\n"
+                       "[00:10.00]正文\n"
+                       "[00:11.00]<00:00.000><00:11.20>尾奏\n"));
+
+    QCOMPARE(lyrics.size(), 3);
+    for (const QVariant &value : lyrics) {
+        const QString text = value.toMap().value(QStringLiteral("text")).toString();
+        QVERIFY2(!text.contains(QLatin1Char('<')), qPrintable(QStringLiteral("残留 '<' : ") + text));
+        QVERIFY2(!text.contains(QLatin1Char('>')), qPrintable(QStringLiteral("残留 '>' : ") + text));
+    }
+    // 无名文本的空标签不应成为首词或被塞进浮层文本
+    QCOMPARE(lyrics.at(0).toMap().value(QStringLiteral("text")).toString(), QStringLiteral("前言"));
+    QCOMPARE(lyrics.at(2).toMap().value(QStringLiteral("text")).toString(), QStringLiteral("尾奏"));
+    const QVariantList lastInfo = lyrics.at(2).toMap().value(QStringLiteral("info")).toList();
+    QCOMPARE(lastInfo.size(), 1);
+    QCOMPARE(lastInfo.at(0).toMap().value(QStringLiteral("offset")).toLongLong(), 200LL);
 }
 
 void LocalLyricsReaderTest::readsSidecarBeforeEmbeddedLyrics()


### PR DESCRIPTION
## 变更

本地音乐此前只有整行高亮（info=null），ID3v2/USLT 只支持普通 LRC，无法逐字。本次按在线逐字歌词同一数据契约（每行 info: [{offset,duration,text}]）为本地歌词补齐字级时间轴：

- cpp/LocalLyricsReader.cpp
  - .lrc / 内嵌 USLT 解析增强 LRC 字级标签 <mm:ss.xx>（绝对时间 → 相对本行 offset/duration）
  - 兼容 KRC 风格 <offset,duration,flag>（与在线酷狗逐字解析一致）
  - ID3v2 SYLT 逐音节时间轴映射为字级 info
  - 无文本内容的空标签不会混入显示文本
- layout/PlayerMaxCenter.qml：逐字行作为末行时的越界保护
- 	ests/local_lyrics_reader_test.cpp：新增增强 LRC / KRC 风格 / 空标签回归测试，全部通过

纯 Qt + TagLib，未硬编码路径，无平台专属代码；侧车歌词仍为同目录同名 .lrc。