### PR TITLE
fix: 本地文件夹音乐列表不把子文件夹当作音乐

### DIFF
--- a/pages/FilePage.qml
+++ b/pages/FilePage.qml
@@ -311,6 +311,7 @@ Item {
                 FolderListModel {
                     id: localFileModel
                     nameFilters: ["*.mp3","*.wav","*.aac","*.flac","*.ogg","*.eac3","*.wma","*.ac3","*.alac","*.mkv","*.wmv","*.avi","*.mpeg4"]
+                    showDirs: false
                 }
 
                 FolderDialog {


### PR DESCRIPTION
## 问题

打开"本地文件夹"里的音乐目录时，FolderListModel 默认 showDirs: true，会把目录内的子文件夹也当成音乐行显示，点击子文件夹还会尝试当作音乐播放。

## 修复

pages/FilePage.qml 中 localFileModel 增加 showDirs: false，列表只显示 
ameFilters 允许的音频/视频文件。

- 纯 QML 改动，跨平台一致（Windows / macOS / Linux）
- 不涉及路径硬编码，不新增任何平台分支