### PR TITLE
feat: improved local songs UX and shortcut controls

### DIFF
--- a/SettingsView.qml
+++ b/SettingsView.qml
@@ -1466,14 +1466,6 @@ Item {
             visible: false
 
             // 动作定义（名称、显示描述、默认键位）
-            property var actionDefs: [
-                { name: "play", desc: "播放/暂停", default: "Space" },
-                { name: "back", desc: "上一首", default: "Left" },
-                { name: "forward", desc: "下一首", default: "Right" },
-                { name: "playList", desc: "打开/关闭播放列表", default: "Alt" },
-                { name: "musicControl", desc: "音乐控制面板", default: "Up" }
-                // 如需添加更多，请在此增加条目，并确保 Options.shortCuts 中存在对应属性
-            ]
             ListModel {
                 id: actionDefs
                 ListElement { name: "play"; desc: "播放/暂停"; defau: "Space" }
@@ -1487,6 +1479,11 @@ Item {
             property string recordingAction: ""
             property bool isRecording: false
             property bool oldShortCutState: false
+
+            // 根据 action 名拼出 Options.settings 里的"该功能是否全局生效"属性名
+            function globalPropertyName(actionName) {
+                return "globalShortcut" + actionName.charAt(0).toUpperCase() + actionName.slice(1)
+            }
 
             // 按键转字符串（辅助函数）
             function keyToString(key) {
@@ -1541,7 +1538,8 @@ Item {
                 recordingAction = action
                 isRecording = true
                 oldShortCutState = Options.settings.openShortCut
-                Options.settings.openShortCut = false   // 暂时禁用全局快捷键，避免干扰
+                Options.settings.openShortCut = false   // 关闭总开关（兼容旧逻辑）
+                Options.settings.recordingShortCut = true   // 录制期间屏蔽所有全局快捷键
                 keyCapture.forceActiveFocus()
                 keyCapture.focus = true;
                 mainWarn.tiped("按下新的快捷键... (按 Esc 取消)", 0)
@@ -1551,6 +1549,7 @@ Item {
             function stopRecording(success, sequence) {
                 isRecording = false
                 Options.settings.openShortCut = oldShortCutState
+                Options.settings.recordingShortCut = false
                 if (success && sequence) {
                     Options.shortCuts[recordingAction] = sequence
                     mainWarn.tiped("已设置快捷键: " + sequence, 1)
@@ -1579,26 +1578,34 @@ Item {
                     font.letterSpacing: -0.3
                 }
 
-                // 全局开关
+                // 全局开关（每个功能单独控制）
                 QHead { text: "全局快捷键" }
                 Rectangle {
                     width: settingStack.standWidth
                     color: Style.themes.primaryColor
                     radius: Style.settings.cubeRadius
+                    height: globalShortCutColumn.height
+                    clip: true
                     Column {
+                        id: globalShortCutColumn
                         width: parent.width
                         padding: 0
-                        Component.onCompleted: parent.height = height
 
-                        SettingItemCard {
-                            label: "启用全局快捷键"
-                            controlItem: QSwitch {
-                                anchors.fill: parent
-                                letRight: true
-                                switchTrue: Options.settings.openShortCut
-                                onToggled: Options.settings.openShortCut = !Options.settings.openShortCut
+                        Repeater {
+                            model: actionDefs
+                            delegate: SettingItemCard {
+                                label: model.desc
+                                controlItem: QSwitch {
+                                    anchors.fill: parent
+                                    letRight: true
+                                    switchTrue: Options.settings[shortcutset.globalPropertyName(model.name)]
+                                    onToggled: {
+                                        var prop = shortcutset.globalPropertyName(model.name);
+                                        Options.settings[prop] = !Options.settings[prop];
+                                    }
+                                }
+                                bottomLine: index !== actionDefs.count - 1
                             }
-                            bottomLine: false
                         }
                     }
                 }

--- a/api/MusicApiService.cpp
+++ b/api/MusicApiService.cpp
@@ -16,6 +16,10 @@
 #include "../cpp/AccountManager.h"
 #include "../cpp/LocalLyricsReader.h"
 
+#include <fileref.h>
+#include <tag.h>
+#include <tstring.h>
+
 namespace {
 constexpr int kSourceKugou = 0;
 constexpr int kSourceNetease = 1;
@@ -29,6 +33,12 @@ QString firstNonEmpty(const QVariantMap &m, std::initializer_list<const char *> 
             return v.toString();
     }
     return QString();
+}
+
+// TagLib 字符串统一转 UTF-8，避免中文歌词/标题乱码
+QString tagString(const TagLib::String &value)
+{
+    return QString::fromUtf8(value.toCString(true));
 }
 } // namespace
 
@@ -243,6 +253,18 @@ QVariantMap MusicApiService::readLocalLyrics(const QString &filePath)
     return LocalLyricsReader::read(filePath);
 }
 
+bool MusicApiService::moveLocalFileToTrash(const QString &filePath)
+{
+    QString localPath = QUrl::fromUserInput(filePath).toLocalFile();
+    if (localPath.isEmpty())
+        localPath = filePath;
+
+    QFile f(localPath);
+    if (!f.exists())
+        return false;
+    return f.moveToTrash();
+}
+
 void MusicApiService::readLocalLyricsAsync(const QString &filePath, const QString &title,
                                            const QString &artist, int duration,
                                            bool allowOnlineSearch)
@@ -298,7 +320,7 @@ void MusicApiService::findLocalLyrics(const QString &filePath, const QString &ti
     searchSongs(keyword, 0, 1, 10, resolvedSource);
 }
 
-// 读取本地音频同目录同名 .json 元数据；不存在返回空 map
+// 读取本地音频同目录同名 .json 元数据；不存在时回退读取音频内嵌 TAG 元数据
 QVariantMap MusicApiService::readLocalMetadata(const QString &filePath)
 {
     QVariantMap meta;
@@ -312,18 +334,36 @@ QVariantMap MusicApiService::readLocalMetadata(const QString &filePath)
     const QFileInfo fi(localPath);
     const QString jsonPath = fi.absolutePath() + QLatin1Char('/')
                              + fi.completeBaseName() + QStringLiteral(".json");
-    if (!QFileInfo::exists(jsonPath))
+    if (QFileInfo::exists(jsonPath)) {
+        QFile f(jsonPath);
+        if (f.open(QIODevice::ReadOnly)) {
+            const QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
+            if (doc.isObject())
+                return doc.object().toVariantMap();
+        }
+    }
+
+    // 无 .json 时读取音频内嵌 TAG，本地歌曲同样能拿到标题/歌手/歌词元数据
+    const QByteArray encodedPath = QFile::encodeName(localPath);
+    TagLib::FileRef ref(encodedPath.constData(), false);
+    if (ref.isNull() || ref.file() == nullptr)
         return meta;
 
-    QFile f(jsonPath);
-    if (!f.open(QIODevice::ReadOnly))
-        return meta;
+    const TagLib::Tag *tag = ref.tag();
+    if (tag) {
+        if (!tag->title().isEmpty())
+            meta.insert(QStringLiteral("title"), tagString(tag->title()));
+        if (!tag->artist().isEmpty())
+            meta.insert(QStringLiteral("artist"), tagString(tag->artist()));
+        if (!tag->album().isEmpty())
+            meta.insert(QStringLiteral("album"), tagString(tag->album()));
+    }
 
-    const QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
-    if (!doc.isObject())
-        return meta;
+    const QVariantMap lyricMap = LocalLyricsReader::read(localPath);
+    if (lyricMap.value(QStringLiteral("found")).toBool())
+        meta.insert(QStringLiteral("lyrics"), lyricMap.value(QStringLiteral("lyrics")));
 
-    return doc.object().toVariantMap();
+    return meta;
 }
 
 // setter

--- a/api/MusicApiService.h
+++ b/api/MusicApiService.h
@@ -145,6 +145,8 @@ public:
     Q_INVOKABLE QVariantMap readLocalMetadata(const QString &filePath);
     // 读取本地歌词：同名 .lrc 优先，其次读取音频内嵌歌词。
     Q_INVOKABLE QVariantMap readLocalLyrics(const QString &filePath);
+    // 把单个本地文件移入系统回收站（找不到/无法移动时返回 false）
+    Q_INVOKABLE bool moveLocalFileToTrash(const QString &filePath);
     // 工作线程解析内嵌标签（避免卡 UI）；命中经 localLyricsReady 回传，未命中自动转在线匹配
     Q_INVOKABLE void readLocalLyricsAsync(const QString &filePath, const QString &title,
                                           const QString &artist, int duration = 0,

--- a/cmake/external/taglib.cmake
+++ b/cmake/external/taglib.cmake
@@ -27,6 +27,8 @@ target_include_directories(quemusic_taglib INTERFACE
     "${_taglib_root}/taglib/mpeg"
     "${_taglib_root}/taglib/mpeg/id3v2"
     "${_taglib_root}/taglib/mpeg/id3v2/frames"
+    "${_taglib_root}/taglib/flac"
+    "${_taglib_root}/taglib/mp4"
 )
 target_link_libraries(quemusic_taglib INTERFACE tag)
 

--- a/components/Options.qml
+++ b/components/Options.qml
@@ -21,6 +21,13 @@ QtObject {
         property bool autoUpdate: false //自动检查更新
         property list<string> searchList: [] //搜索记录
         property bool openShortCut: true
+        property bool recordingShortCut: false // 正在录制快捷键时禁用所有全局快捷键，避免组合键被拦截
+        // 每个功能单独控制是否为全局快捷键（#44：不要用总开关控制所有功能）
+        property bool globalShortcutPlay: true
+        property bool globalShortcutBack: true
+        property bool globalShortcutForward: true
+        property bool globalShortcutPlayList: true
+        property bool globalShortcutMusicControl: true
         
         //播放器
         property int soundQuality: 1 //音质

--- a/components/QButton.qml
+++ b/components/QButton.qml
@@ -13,6 +13,7 @@ Button {
     text: "Button"              // 按钮文字
     property string iconCharacter: ""          // 图标字符
     property string iconFontFamily: iconFont.name    // 图标字体
+    property string tipText: ""                // 鼠标悬停提示文字（为空则不显示）
 
     // ==== 样式 ====
     property color textColor: Style.themes.fontColor      // 文字颜色
@@ -97,5 +98,10 @@ Button {
                 verticalAlignment: Text.AlignVCenter
             }
         }
+    }
+
+    QTip {
+        visible: root.tipText !== "" && root.hovered
+        text: root.tipText
     }
 }

--- a/components/SButton.qml
+++ b/components/SButton.qml
@@ -13,6 +13,7 @@ Button {
     // ==== 外部接口 ====
     property string iconCharacter: ""          // 图标字符 (FontAwesome 等)
     property string iconFontFamily: iconFont.name    // 图标字体
+    property string tipText: ""                // 鼠标悬停提示文字（为空则不显示）
 
     // ==== 样式 ====
     property color iconColor: Style.themes.textColor
@@ -71,5 +72,10 @@ Button {
         font.family: root.iconFontFamily
         verticalAlignment: Text.AlignVCenter
         horizontalAlignment: Text.AlignHCenter
+    }
+
+    QTip {
+        visible: root.tipText !== "" && root.hovered
+        text: root.tipText
     }
 }

--- a/cpp/CoverHelper.cpp
+++ b/cpp/CoverHelper.cpp
@@ -5,10 +5,23 @@
 
 #include <QDebug>
 #include <QDir>
+#include <QFile>
 #include <QFileInfo>
 #include <QHashFunctions>
+#include <QCryptographicHash>
 #include <QStandardPaths>
 #include <QUrl>
+
+#include <fileref.h>
+#include <mpegfile.h>
+#include <id3v2tag.h>
+#include <attachedpictureframe.h>
+#include <flacfile.h>
+#include <flacpicture.h>
+#include <mp4file.h>
+#include <mp4tag.h>
+#include <mp4coverart.h>
+#include <tpropertymap.h>
 
 namespace {
 
@@ -59,6 +72,18 @@ QString CoverHelper::convertVariantToUrl(const QVariant &imageVariant)
     return url;
 }
 
+QString CoverHelper::storageCachePath(const QString &localPath) const
+{
+    const QFileInfo fi(localPath);
+    const QByteArray seed = (fi.absoluteFilePath() + QLatin1Char('@')
+                           + QString::number(fi.lastModified().toMSecsSinceEpoch()))
+                                .toUtf8();
+    // 用内容固定的哈希，跨系统 / 跨进程结果一致，不依赖 Qt 的散列种子
+    const QString digest = QString::fromLatin1(
+        QCryptographicHash::hash(seed, QCryptographicHash::Sha1).toHex());
+    return m_cacheDir + QStringLiteral("/cover-") + digest + QStringLiteral(".png");
+}
+
 QString CoverHelper::findLocalCover(const QString &sourcePath)
 {
     if (sourcePath.isEmpty())
@@ -73,6 +98,7 @@ QString CoverHelper::findLocalCover(const QString &sourcePath)
     if (!fi.isFile())
         return QString();
 
+    QString found;
     const QDir dir = fi.absoluteDir();
     const QStringList entries = dir.entryList(QDir::Files);
 
@@ -87,12 +113,96 @@ QString CoverHelper::findLocalCover(const QString &sourcePath)
         for (const QString &ext : extensions) {
             const QString target = name + QLatin1Char('.') + ext;
             for (const QString &entry : entries) {
-                if (entry.compare(target, Qt::CaseInsensitive) == 0)
-                    return QUrl::fromLocalFile(dir.filePath(entry)).toString();
+                if (entry.compare(target, Qt::CaseInsensitive) == 0) {
+                    found = QUrl::fromLocalFile(dir.filePath(entry)).toString();
+                    break;
+                }
+            }
+            if (!found.isEmpty())
+                break;
+        }
+        if (!found.isEmpty())
+            break;
+    }
+
+    return found;
+}
+
+QString CoverHelper::findEmbeddedCover(const QString &sourcePath)
+{
+    QString localPath = sourcePath;
+    const QUrl asUrl(sourcePath);
+    if (asUrl.isLocalFile())
+        localPath = asUrl.toLocalFile();
+    const QFileInfo fi(localPath);
+    if (!fi.isFile())
+        return QString();
+
+    // 存储缓存：文件存在就直接返回，跨进程、跨重启有效，不用再拆包解析
+    const QString cacheFilePath = storageCachePath(localPath);
+    if (QFileInfo::exists(cacheFilePath))
+        return QUrl::fromLocalFile(cacheFilePath).toString();
+
+    const QByteArray encodedPath = QFile::encodeName(localPath);
+    TagLib::FileRef ref(encodedPath.constData(), false);
+    QString coverUrl;
+    if (!ref.isNull() && ref.file() != nullptr) {
+        TagLib::ByteVector coverData;
+
+        if (auto *mpeg = dynamic_cast<TagLib::MPEG::File *>(ref.file())) {
+            if (auto *id3v2 = mpeg->ID3v2Tag()) {
+                const auto frames = id3v2->frameList("APIC");
+                for (auto *frame : frames) {
+                    auto *pic = dynamic_cast<TagLib::ID3v2::AttachedPictureFrame *>(frame);
+                    if (!pic || pic->picture().isEmpty())
+                        continue;
+                    if (pic->type() == TagLib::ID3v2::AttachedPictureFrame::FrontCover) {
+                        coverData = pic->picture();
+                        break;
+                    }
+                    if (coverData.isEmpty())
+                        coverData = pic->picture();
+                }
+            }
+        } else if (auto *flac = dynamic_cast<TagLib::FLAC::File *>(ref.file())) {
+            const auto pictures = flac->pictureList();
+            for (auto *pic : pictures) {
+                if (!pic || pic->data().isEmpty())
+                    continue;
+                if (pic->type() == TagLib::FLAC::Picture::FrontCover) {
+                    coverData = pic->data();
+                    break;
+                }
+                if (coverData.isEmpty())
+                    coverData = pic->data();
+            }
+        } else if (auto *mp4 = dynamic_cast<TagLib::MP4::File *>(ref.file())) {
+            if (mp4->tag()) {
+                const TagLib::MP4::CoverArtList covers =
+                    mp4->tag()->item("covr").toCoverArtList();
+                for (const auto &cover : covers) {
+                    if (!cover.data().isEmpty()) {
+                        coverData = cover.data();
+                        break;
+                    }
+                }
+            }
+        }
+
+        if (!coverData.isEmpty()) {
+            QImage image;
+            image.loadFromData(QByteArray(coverData.data(), coverData.size()));
+            if (!image.isNull()) {
+                if (qMax(image.width(), image.height()) > kMaxCoverSize)
+                    image = image.scaled(kMaxCoverSize, kMaxCoverSize, Qt::KeepAspectRatio,
+                                         Qt::FastTransformation);
+                if (image.save(cacheFilePath, "PNG"))
+                    coverUrl = QUrl::fromLocalFile(cacheFilePath).toString();
             }
         }
     }
-    return QString();
+
+    return coverUrl;
 }
 
 void CoverHelper::clearCache()

--- a/cpp/CoverHelper.h
+++ b/cpp/CoverHelper.h
@@ -27,6 +27,10 @@ public:
     // 音频同目录查找同名/常见命名封面（cover/folder/AlbumArt），未命中返回空
     Q_INVOKABLE QString findLocalCover(const QString &sourcePath);
 
+    // 读取音频文件内嵌封面（ID3v2 APIC / FLAC Picture / MP4 covr），
+    // 命中后写入封面缓存并返回 file:// URL，未命中返回空。
+    Q_INVOKABLE QString findEmbeddedCover(const QString &sourcePath);
+
     Q_INVOKABLE void clearCache();
 
 signals:
@@ -35,6 +39,8 @@ signals:
 private:
     void setCoverUrl(const QString &url);
     static QImage toImage(const QVariant &value);
+    // 存储缓存文件路径：由「绝对路径 + 修改时间」派生，进程重启后仍然命中
+    QString storageCachePath(const QString &localPath) const;
 
     QString m_currentCoverUrl;
     QString m_cacheDir;

--- a/cpp/FolderModel.cpp
+++ b/cpp/FolderModel.cpp
@@ -4,6 +4,7 @@
 #include "FolderModel.h"
 #include <QSqlQuery>
 #include <QSqlError>
+#include <QSqlDriver>
 #include <QStandardPaths>
 #include <QDir>
 #include <QDebug>
@@ -223,6 +224,21 @@ QHash<int, QByteArray> SongModel::roleNames() const
     };
 }
 
+QVariantMap SongModel::get(int index) const
+{
+    if (index < 0 || index >= m_items.size())
+        return {};
+    const SongItem &item = m_items.at(index);
+    QVariantMap map;
+    map.insert(QStringLiteral("songId"), item.id);
+    map.insert(QStringLiteral("folderId"), item.folderId);
+    map.insert(QStringLiteral("name"), item.name);
+    map.insert(QStringLiteral("path"), item.path);
+    map.insert(QStringLiteral("singer"), item.singer);
+    map.insert(QStringLiteral("duration"), item.duration);
+    return map;
+}
+
 void SongModel::loadByFolder(int folderId)
 {
     m_folderId = folderId;
@@ -246,6 +262,50 @@ int SongModel::addSong(int folderId, const QString &name, const QString &path, c
         refreshModel();
     }
     return newId;
+}
+
+int SongModel::addSongs(int folderId, const QVariantList &songs)
+{
+    if (songs.isEmpty())
+        return 0;
+
+    // 批量导入时用单个事务承载全部 INSERT，最后统一刷新一次模型，
+    // 避免逐条 addSong 带来的事务/刷新开销把 UI 卡成假死。
+    bool ownTransaction = false;
+    if (m_db.driver() && m_db.driver()->hasFeature(QSqlDriver::Transactions)) {
+        ownTransaction = m_db.transaction();
+    }
+
+    QSqlQuery query(m_db);
+    query.prepare("INSERT INTO songs (folder_id, name, path, singer) VALUES (:folder_id, :name, :path, :singer)");
+    int added = 0;
+    for (const QVariant &entry : songs) {
+        const QVariantMap song = entry.toMap();
+        const QString name = song.value(QStringLiteral("name")).toString();
+        const QString path = song.value(QStringLiteral("path")).toString();
+        if (name.isEmpty() || path.isEmpty())
+            continue;
+        query.bindValue(":folder_id", folderId);
+        query.bindValue(":name", name);
+        query.bindValue(":path", path);
+        query.bindValue(":singer", song.value(QStringLiteral("singer")).toString());
+        if (query.exec()) {
+            ++added;
+        } else {
+            emit errorOccurred(QStringLiteral("添加歌曲失败: ") + query.lastError().text());
+        }
+    }
+
+    if (ownTransaction && !m_db.commit()) {
+        m_db.rollback();
+        emit errorOccurred(QStringLiteral("提交批量导入失败: ") + m_db.lastError().text());
+        return 0;
+    }
+
+    if (folderId == m_folderId) {
+        refreshModel();
+    }
+    return added;
 }
 
 bool SongModel::deleteSong(int songId)

--- a/cpp/FolderModel.h
+++ b/cpp/FolderModel.h
@@ -93,7 +93,9 @@ public:
 
     // QML 可调用的方法
     Q_INVOKABLE void loadByFolder(int folderId);
+    Q_INVOKABLE QVariantMap get(int index) const;
     Q_INVOKABLE int addSong(int folderId, const QString &name, const QString &path, const QString &singer = "");
+    Q_INVOKABLE int addSongs(int folderId, const QVariantList &songs);
     Q_INVOKABLE bool deleteSong(int songId);
 
     int folderId() const { return m_folderId; }

--- a/layout/PlayerControl.qml
+++ b/layout/PlayerControl.qml
@@ -292,6 +292,9 @@ Rectangle {
             hoverColor: Style.themes.hoverColor
             iconColor: Style.themes.textColor
             shadowEnabled: false
+            visible: playListModel.count > 0 && playListModel.playListIndex >= 0
+                     && playListModel.playListIndex < playListModel.count
+                     && playListModel.get(playListModel.playListIndex).source !== -1
             onClicked: {
                 if(playListModel.get(playListModel.playListIndex).path) {
                     if(Options.settings.soundQuality === 0) {

--- a/layout/PlayerMaxCenter.qml
+++ b/layout/PlayerMaxCenter.qml
@@ -392,21 +392,30 @@ Item {
                     lyricContent.finalH = 0;
                     fixedAnime.running = true;
                 }
-                if(MusicApi.lyricsData[idx].info && idx + 1 < MusicApi.lyricsData.length) {
-                    var lyricLastLineData = MusicApi.lyricsData[idx].info[MusicApi.lyricsData[idx].info.length - 1];
-                    if(MusicApi.lyricsData[idx + 1].time - MusicApi.lyricsData[idx].time - lyricLastLineData.offset - lyricLastLineData.duration > 2500 && mainMedia.position > MusicApi.lyricsData[idx].time + lyricLastLineData.offset + lyricLastLineData.duration) {
-                        if(!waitAnimeSection.visible) {
-                            console.log("开始运行等待动画。");
-                            waitOpenAnime.running = false;
-                            waitOutAnime.running = false;
-                            waitOpenAnime.running = true;
-                            for (var i = 0; i <= idx; i++) {
-                                var basicIndexY = lyricContent.prefixSum[lyricContent.currentLine + 1];
-                                if (lyricRep.itemAt(i)) lyricRep.itemAt(i).animeTo(Math.floor(lyricContent.prefixSum[i] - basicIndexY + lyricContent.height * lyricContent.alignPos), false);
-                            }
-                            for (var i = idx + 1; i < lyricRep.count; i++) {
-                                var basicIndexY = lyricContent.prefixSum[lyricContent.currentLine + 1];
-                                if (lyricRep.itemAt(i)) lyricRep.itemAt(i).animeTo(Math.floor(lyricContent.prefixSum[i] - basicIndexY + lyricContent.height * lyricContent.alignPos + musicControlMax.standHeight), false);
+                var currentLineData = MusicApi.lyricsData[idx];
+                var currentInfo = currentLineData ? currentLineData.info : undefined;
+                if (currentInfo && currentInfo.length > 0 && idx + 1 < MusicApi.lyricsData.length) {
+                    var lyricLastLineData = currentInfo[currentInfo.length - 1];
+                    var nextLineData = MusicApi.lyricsData[idx + 1];
+                    if (lyricLastLineData && nextLineData
+                        && (lyricLastLineData.offset !== undefined)
+                        && (lyricLastLineData.duration !== undefined)
+                        && (nextLineData.time !== undefined)
+                        && (currentLineData.time !== undefined)) {
+                        if (nextLineData.time - currentLineData.time - lyricLastLineData.offset - lyricLastLineData.duration > 2500 && mainMedia.position > currentLineData.time + lyricLastLineData.offset + lyricLastLineData.duration) {
+                            if(!waitAnimeSection.visible) {
+                                console.log("开始运行等待动画。");
+                                waitOpenAnime.running = false;
+                                waitOutAnime.running = false;
+                                waitOpenAnime.running = true;
+                                for (var i = 0; i <= idx; i++) {
+                                    var basicIndexY = lyricContent.prefixSum[lyricContent.currentLine + 1];
+                                    if (lyricRep.itemAt(i)) lyricRep.itemAt(i).animeTo(Math.floor(lyricContent.prefixSum[i] - basicIndexY + lyricContent.height * lyricContent.alignPos), false);
+                                }
+                                for (var i = idx + 1; i < lyricRep.count; i++) {
+                                    var basicIndexY = lyricContent.prefixSum[lyricContent.currentLine + 1];
+                                    if (lyricRep.itemAt(i)) lyricRep.itemAt(i).animeTo(Math.floor(lyricContent.prefixSum[i] - basicIndexY + lyricContent.height * lyricContent.alignPos + musicControlMax.standHeight), false);
+                                }
                             }
                         }
                     }
@@ -675,7 +684,22 @@ Item {
         SequentialAnimation {
             id: waitOpenAnime
             property int lightDuration: 2500
-            ScriptAction { script: { waitAnimeSection.visible = true; waitAnimeSection.lightState = 0; waitOpenAnime.lightDuration = MusicApi.lyricsData[lyricContent.currentLine + 1].time - MusicApi.lyricsData[lyricContent.currentLine].time - MusicApi.lyricsData[lyricContent.currentLine].info[MusicApi.lyricsData[lyricContent.currentLine].info.length - 1].offset - MusicApi.lyricsData[lyricContent.currentLine].info[MusicApi.lyricsData[lyricContent.currentLine].info.length - 1].duration - 420 } }
+            ScriptAction { script: {
+                 waitAnimeSection.visible = true;
+                 waitAnimeSection.lightState = 0;
+                 var line = MusicApi.lyricsData[lyricContent.currentLine];
+                 var next = MusicApi.lyricsData[lyricContent.currentLine + 1];
+                 if (line && next && line.info && line.info.length > 0
+                     && (next.time !== undefined) && (line.time !== undefined)) {
+                     var last = line.info[line.info.length - 1];
+                     if (last && (last.offset !== undefined) && (last.duration !== undefined))
+                         waitOpenAnime.lightDuration = next.time - line.time - last.offset - last.duration - 420;
+                     else
+                         waitOpenAnime.lightDuration = 2500;
+                 } else {
+                     waitOpenAnime.lightDuration = 2500;
+                 }
+             } }
             PauseAnimation { duration: 100 }
             ParallelAnimation {
                 NumberAnimation { target: waitAnimeSection; property: "opacity"; from: 0; to: 1; duration: 460; easing.type: Easing.OutCubic }

--- a/main.qml
+++ b/main.qml
@@ -83,12 +83,15 @@ Window {
         if (hasMeta) {
             mainMedia.urlLocal = false;
             mainMedia.noTitle = title;
-            mainMedia.urlStr = meta.cover || "qrc:/QueMusic/resources/app/musicpic.png";
+            var localCover = meta.cover || coverHelper.findEmbeddedCover(path)
+                             || coverHelper.findLocalCover(path);
+            mainMedia.urlStr = localCover || "qrc:/QueMusic/resources/app/musicpic.png";
             window.musicTitle = title;
             window.musicArtist = artist;
             MusicApi.lyricsData = meta.lyrics || [];
             MusicApi.lyricsTranslate = meta.translate || [];
-            colorExtractor.extractColorsFromUrl(meta.cover);
+            if (localCover)
+                colorExtractor.extractColorsFromUrl(localCover);
         } else {
             mainMedia.urlLocal = true;
             mainMedia.noTitle = name;
@@ -144,6 +147,7 @@ Window {
     Shortcut {
         sequence: "Esc" // 返回
         context: Qt.ApplicationShortcut
+        enabled: !Options.settings.recordingShortCut // 录制快捷键时不抢 Esc，交给录制框处理
         onActivated: {
             window.exit();
             console.log("Exit");
@@ -156,7 +160,7 @@ Window {
     Shortcut {
         sequence: Options.shortCuts.play // 暂停/播放
         context: Qt.ApplicationShortcut
-        enabled: Options.settings.openShortCut
+        enabled: !Options.settings.recordingShortCut && Options.settings.globalShortcutPlay
         onActivated: {
             console.log("shortcut--play")
             if (mainMedia.playing === false) {
@@ -170,7 +174,7 @@ Window {
     Shortcut {
         sequence: Options.shortCuts.back // 上一首
         context: Qt.ApplicationShortcut
-        enabled: Options.settings.openShortCut
+        enabled: !Options.settings.recordingShortCut && Options.settings.globalShortcutBack
         onActivated: {
             console.log("shortcut--back")
             musicControlMin.lastMedia();
@@ -179,7 +183,7 @@ Window {
     Shortcut {
         sequence: Options.shortCuts.forward // 下一首
         context: Qt.ApplicationShortcut
-        enabled: Options.settings.openShortCut
+        enabled: !Options.settings.recordingShortCut && Options.settings.globalShortcutForward
         onActivated: {
             console.log("shortcut--forward")
             musicControlMin.enterMedia();
@@ -188,7 +192,7 @@ Window {
     Shortcut {
         sequence: Options.shortCuts.playList // 播放菜单
         context: Qt.ApplicationShortcut
-        enabled: Options.settings.openShortCut
+        enabled: !Options.settings.recordingShortCut && Options.settings.globalShortcutPlayList
         onActivated: {
             console.log("shortcut--playList")
             if(playList.visible) {
@@ -201,7 +205,7 @@ Window {
     Shortcut {
         sequence: Options.shortCuts.musicControl // 播放模式切换
         context: Qt.ApplicationShortcut
-        enabled: Options.settings.openShortCut
+        enabled: !Options.settings.recordingShortCut && Options.settings.globalShortcutMusicControl
         onActivated: {
             if(mainLayout.state === "") {
                 controlMaxLoader.active = true;

--- a/pages/FilePage.qml
+++ b/pages/FilePage.qml
@@ -16,6 +16,100 @@ Item {
     signal loaded()
     signal cancelChoose()
 
+    // 在播放列表中查找同名/同路径歌曲，避免重复添加本地文件
+    function findIndexByValue(model, key, targetValue) {
+        for (var i = 0; i < model.count; i++) {
+            var element = model.get(i);
+            if (element && element[key] === targetValue) {
+                return i;
+            }
+        }
+        return -1; // 未找到返回 -1
+    }
+
+    // 把「我的文件夹」歌曲模型里的歌全部加入播放列表，play=true 时立即播放
+    function addAllSongModelToList(play) {
+        if (songModel.count === 0) {
+            Style.warned("当前文件夹没有歌曲", 0);
+            return;
+        }
+        var playFirst = -1;
+        var added = 0;
+        for (var i = 0; i < songModel.count; i++) {
+            var item = songModel.get(i);
+            if (!item || !item.name || !item.path) continue;
+            if (filePage.findIndexByValue(playListModel, "path", item.path) !== -1) continue;
+            playListModel.append({ name: item.name, path: item.path, songer: item.singer || "", source: -1 });
+            if (playFirst === -1) playFirst = playListModel.count - 1;
+            added++;
+        }
+        if (added === 0) {
+            Style.warned("列表中的歌曲都已在播放列表中", 0);
+        } else {
+            Style.warned("成功加入播放列表 " + added + " 首", 1);
+        }
+        if (play && playFirst !== -1) {
+            playListModel.playListIndex = playFirst;
+            musicControlMin.refreshMusicPlay();
+        }
+    }
+
+    // 把「本地文件夹」里扫描到的音频文件全部加入播放列表，play=true 时立即播放
+    function addAllLocalFilesToList(play) {
+        if (localFileModel.count === 0) {
+            Style.warned("当前文件夹没有音频文件", 0);
+            return;
+        }
+        var playFirst = -1;
+        var added = 0;
+        for (var i = 0; i < localFileModel.count; i++) {
+            var name = localFileModel.get(i, "fileName");
+            var fileUrl = localFileModel.get(i, "fileUrl");
+            if (!name || !fileUrl) continue;
+            var path = fileUrl.toString();
+            if (filePage.findIndexByValue(playListModel, "path", path) !== -1) continue;
+            playListModel.append({ name: name, path: path, songer: "", source: -1 });
+            if (playFirst === -1) playFirst = playListModel.count - 1;
+            added++;
+        }
+        if (added === 0) {
+            Style.warned("列表中的歌曲都已在播放列表中", 0);
+        } else {
+            Style.warned("成功加入播放列表 " + added + " 首", 1);
+        }
+        if (play && playFirst !== -1) {
+            playListModel.playListIndex = playFirst;
+            musicControlMin.refreshMusicPlay();
+        }
+    }
+
+    // 打开某个歌曲文件的所在文件夹（本地浏览器）
+    function openSongFolder(songPath) {
+        var p = songPath || "";
+        if (p.startsWith("file:///"))
+            p = p.substring(8);
+        var idx = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
+        var dir = idx > 0 ? p.substring(0, idx) : p;
+        if (dir) {
+            Qt.openUrlExternally(dir);
+        } else {
+            Style.warned("无法定位所在文件夹", 0);
+        }
+    }
+
+    // 刷新当前浏览的音频列表：重新从磁盘/数据库读取
+    function refreshSongList() {
+        if (songModel.folderId >= 0) {
+            songModel.loadByFolder(songModel.folderId);
+        }
+        if (localFileModel.folder.toString()) {
+            var folder = localFileModel.folder;
+            localFileModel.folder = "";
+            localFileModel.folder = folder;
+        }
+        Style.warned("已刷新当前列表", 1);
+    }
+
     // 首页面
     Item {
         id: fileMain
@@ -249,7 +343,13 @@ Item {
                                     buttonColor: "transparent"
                                     hoverColor: Qt.rgba(0.5,0.5,0.5,0.2)
                                     shadowEnabled: false
+                                    tipText: model.path ? "打开文件夹位置" : "应用逻辑文件夹（无磁盘路径）"
                                     onClicked: {
+                                        if (model.path) {
+                                            Qt.openUrlExternally(model.path);
+                                        } else {
+                                            Style.warned("「我的文件夹」没有关联的磁盘路径", 0);
+                                        }
                                     }
                                 }
                                 SButton {
@@ -260,6 +360,7 @@ Item {
                                     buttonColor: "transparent"
                                     hoverColor: Qt.rgba(0.5,0.5,0.5,0.2)
                                     shadowEnabled: false
+                                    tipText: "重命名文件夹"
 
                                     onClicked: {
                                         if(model.folderId !== 1) {
@@ -280,6 +381,7 @@ Item {
                                     buttonColor: "transparent"
                                     hoverColor: Qt.rgba(1.0,0.5,0.5,0.8)
                                     shadowEnabled: false
+                                    tipText: "删除文件夹"
                                     onClicked: {
                                         if(model.folderId !== 1) {
                                             //myfileModel.remove( index, 1 )
@@ -485,7 +587,13 @@ Item {
                                     buttonColor: "transparent"
                                     hoverColor: Qt.rgba(0.5,0.5,0.5,0.2)
                                     shadowEnabled: false
+                                    tipText: "打开文件夹位置"
                                     onClicked: {
+                                        if (model.path) {
+                                            Qt.openUrlExternally(model.path);
+                                        } else {
+                                            Style.warned("无法定位文件夹", 0);
+                                        }
                                     }
                                 }
                                 SButton {
@@ -496,6 +604,7 @@ Item {
                                     buttonColor: "transparent"
                                     hoverColor: Qt.rgba(0.5,0.5,0.5,0.2)
                                     shadowEnabled: false
+                                    tipText: "重命名文件夹"
 
                                     onClicked: {
                                         editLocalDialog.input = model.name
@@ -511,6 +620,7 @@ Item {
                                     buttonColor: "transparent"
                                     hoverColor: Qt.rgba(1.0,0.5,0.5,0.8)
                                     shadowEnabled: false
+                                    tipText: "删除文件夹"
                                     onClicked: {
                                         globalDialog.openSimpleDialog("删除", "这将删除本文件夹，无法恢复，是否删除？",
                                             function() {
@@ -551,28 +661,23 @@ Item {
                     // 获取选中的文件URL（file:// 格式）
                     var fileUrls = musicfileDialog.selectedFiles;
 
-                    // 将URL转换为本地文件路径（去掉 'file:///' 前缀）
+                    // 先批量转换为本地路径，再一次交给 C++ 侧事务写入，
+                    // 避免上千首歌曲重复打开DB/刷新列表导致界面假死。
+                    var importList = [];
                     for (var i = 0; i < fileUrls.length; i++) {
-                        var fileUrl = fileUrls[i];
-                        var filePath = fileUrl.toString();
+                        var filePath = fileUrls[i].toString();
                         if (filePath.startsWith("file:///")) {
                             filePath = filePath.substring(8);// 去前8字符：file:///
                         }
-
-                        // 从完整路径中提取纯文件名（例如从 'C:/Users/me/doc.txt' 提取 'doc.txt'）
                         var fileName = filePath.split('/').pop(); // 使用 '/' 分割，取最后一部分
+                        if (fileName && filePath) {
+                            importList.push({ name: fileName, path: filePath, singer: "" });
+                        }
+                    }
 
-                        console.log("文件URL: ", fileUrl);
-                        console.log("文件路径: ", filePath);
-                        console.log("文件名: ", fileName);
-
-                        // 现在你可以使用 fileName 或 filePath 进行后续操作，例如显示、读取等
-                        let musics = [];
-                        //musics.push({name:fileName,path:filePath,songer:""});
-                        //myfileModel.get(filePage.folderNumber).music.append(musics);
-                        songModel.addSong(songModel.folderId, fileName, filePath, "");
-                        Style.warned("成功导入音乐",1);
-                        //filePage.loaded()
+                    if (importList.length > 0) {
+                        var added = songModel.addSongs(songModel.folderId, importList);
+                        Style.warned("成功导入 " + added + " 首音乐", 1);
                     }
                 }
                 onRejected: {
@@ -593,7 +698,9 @@ Item {
                     text: "播放"
                     shadowEnabled: false
                     buttonColor: Style.themes.sideColor
+                    tipText: "播放当前文件夹全部歌曲"
                     onClicked: {
+                        filePage.addAllSongModelToList(true);
                     }
                 }
                 SButton {
@@ -603,7 +710,9 @@ Item {
                     iconCharacter: "\uf095"
                     shadowEnabled: false
                     buttonColor: Style.themes.sideColor
+                    tipText: "全部加入播放列表"
                     onClicked: {
+                        filePage.addAllSongModelToList(false);
                     }
                 }
                 SButton {
@@ -613,7 +722,9 @@ Item {
                     iconCharacter: "\uf0c8"
                     shadowEnabled: false
                     buttonColor: Style.themes.sideColor
+                    tipText: "刷新当前文件夹"
                     onClicked: {
+                        filePage.refreshSongList();
                     }
                 }
             }
@@ -647,6 +758,19 @@ Item {
                     radius: Style.settings.labelRadius
                     color: mainMedia.noTitle == model.name ? Style.themes.containColor : "transparent"
 
+                    // 列表内封面：内嵌封面 -> 同目录封面 -> .json 封面 -> 默认图标
+                    property string coverUrl: {
+                        if (!model.path) return "";
+                        var path = model.path;
+                        var embedded = coverHelper.findEmbeddedCover(path);
+                        if (embedded) return embedded;
+                        var local = coverHelper.findLocalCover(path);
+                        if (local) return local;
+                        var meta = MusicApi.readLocalMetadata(path);
+                        if (meta && meta.cover) return meta.cover;
+                        return "";
+                    }
+
                     Behavior on color { ColorAnimation { duration: 120 } }
 
                     Rectangle {
@@ -665,6 +789,15 @@ Item {
                             color: Style.themes.fontColor
                             horizontalAlignment: Text.AlignHCenter
                             verticalAlignment: Text.AlignVCenter
+                        }
+                        QPicture {
+                            anchors.fill: parent
+                            source: listfile.coverUrl
+                            visible: listfile.coverUrl !== ""
+                            radius1: 10
+                            radius2: 10
+                            radius3: 10
+                            radius4: 10
                         }
                     }
 
@@ -722,6 +855,7 @@ Item {
                                 buttonColor: "transparent"
                                 hoverColor: Qt.rgba(0.5,0.5,0.5,0.2)
                                 shadowEnabled: false
+                                tipText: "加入播放列表"
                                 onClicked: {
                                     var musicName = model.name;
                                     var musicPath = model.path;
@@ -741,7 +875,9 @@ Item {
                                 buttonColor: "transparent"
                                 hoverColor: Qt.rgba(0.5,0.5,0.5,0.2)
                                 shadowEnabled: false
+                                tipText: "打开所在文件夹"
                                 onClicked: {
+                                    filePage.openSongFolder(model.path);
                                 }
                             }
                             SButton {
@@ -753,6 +889,7 @@ Item {
                                 buttonColor: "transparent"
                                 hoverColor: Qt.rgba(1.0,0.5,0.5,0.8)
                                 shadowEnabled: false
+                                tipText: "从当前文件夹移除"
                                 onClicked: {
                                     //myfileModel.get(filePage.folderNumber).music.remove(index)
                                     songModel.deleteSong(model.songId);
@@ -796,7 +933,9 @@ Item {
                     text: "播放"
                     shadowEnabled: false
                     buttonColor: Style.themes.sideColor
+                    tipText: "播放当前文件夹全部歌曲"
                     onClicked: {
+                        filePage.addAllLocalFilesToList(true);
                     }
                 }
                 SButton {
@@ -806,7 +945,9 @@ Item {
                     iconCharacter: "\uf095"
                     shadowEnabled: false
                     buttonColor: Style.themes.sideColor
+                    tipText: "全部加入播放列表"
                     onClicked: {
+                        filePage.addAllLocalFilesToList(false);
                     }
                 }
                 SButton {
@@ -816,7 +957,9 @@ Item {
                     iconCharacter: "\uf0c8"
                     shadowEnabled: false
                     buttonColor: Style.themes.sideColor
+                    tipText: "刷新当前文件夹"
                     onClicked: {
+                        filePage.refreshSongList();
                     }
                 }
             }
@@ -878,6 +1021,19 @@ Item {
                     radius: Style.settings.labelRadius
                     color: mainMedia.source == model.fileUrl ? Style.themes.containColor : "transparent"
 
+                    // 列表内封面：内嵌封面 -> 同目录封面 -> .json 封面 -> 默认图标
+                    property string coverUrl: {
+                        if (!model.fileUrl) return "";
+                        var path = model.fileUrl.toString();
+                        var embedded = coverHelper.findEmbeddedCover(path);
+                        if (embedded) return embedded;
+                        var local = coverHelper.findLocalCover(path);
+                        if (local) return local;
+                        var meta = MusicApi.readLocalMetadata(path);
+                        if (meta && meta.cover) return meta.cover;
+                        return "";
+                    }
+
                     Behavior on color { ColorAnimation { duration: 120 } }
 
                     Rectangle {
@@ -896,6 +1052,15 @@ Item {
                             color: Style.themes.fontColor
                             horizontalAlignment: Text.AlignHCenter
                             verticalAlignment: Text.AlignVCenter
+                        }
+                        QPicture {
+                            anchors.fill: parent
+                            source: listLocalFile.coverUrl
+                            visible: listLocalFile.coverUrl !== ""
+                            radius1: 10
+                            radius2: 10
+                            radius3: 10
+                            radius4: 10
                         }
                     }
 
@@ -952,6 +1117,7 @@ Item {
                                 buttonColor: "transparent"
                                 hoverColor: Qt.rgba(0.5,0.5,0.5,0.2)
                                 shadowEnabled: false
+                                tipText: "加入播放列表"
                                 onClicked: {
                                     var musicName = model.fileName;
                                     var musicPath = model.fileUrl.toString();
@@ -969,7 +1135,9 @@ Item {
                                 buttonColor: "transparent"
                                 hoverColor: Qt.rgba(0.5,0.5,0.5,0.2)
                                 shadowEnabled: false
+                                tipText: "打开所在文件夹"
                                 onClicked: {
+                                    filePage.openSongFolder(model.fileUrl.toString());
                                 }
                             }
                             SButton {
@@ -980,8 +1148,22 @@ Item {
                                 buttonColor: "transparent"
                                 hoverColor: Qt.rgba(1.0,0.5,0.5,0.8)
                                 shadowEnabled: false
+                                tipText: "从本地文件夹移除（移入回收站）"
                                 onClicked: {
-                                    myfileModel.get(filePage.folderNumber).music.remove(index);
+                                    var targetName = model.fileName;
+                                    var targetPath = model.fileUrl.toString();
+                                    globalDialog.openSimpleDialog("移除本地文件", "这将把「" + targetName + "」从当前文件夹移入回收站，是否继续？",
+                                        function() {
+                                            if (MusicApi.moveLocalFileToTrash(targetPath)) {
+                                                Style.warned("已将文件移入回收站", 1);
+                                                var folder = localFileModel.folder;
+                                                localFileModel.folder = "";
+                                                localFileModel.folder = folder;
+                                            } else {
+                                                Style.warned("移动文件失败", 0);
+                                            }
+                                        }
+                                    );
                                 }
                             }
                         }


### PR DESCRIPTION
批量处理以下 issue：

## 修复
- #41 图标按钮增加鼠标悬停提示（SButton/QButton 新增 	ipText，文件页图标按钮补齐）
- #42 录制快捷键时屏蔽其他全局快捷键（新增 ecordingShortCut 状态）
- #44 全局快捷键改为每个功能单独开关
- #48 本地歌曲元数据歌词加载（无 .json 时回退读取音频内嵌 TAG，标题/歌手/歌词）
- #18/#40 本地歌曲列表封面不显示（内嵌封面/同目录封面 + 存储缓存，标准应用数据目录，无硬编码路径）

## 新增
- #43 补全本地页无效果按钮：播放全部、全部加入播放列表、刷新列表、打开所在文件夹、移入回收站

## 优化
- #46 批量导入多首歌曲改为单事务写入 + 单次刷新，避免假死
- #47 本地歌曲隐藏下载按钮

## 其他
- PlayerMaxCenter 逐字歌词等待动画越界防护，消除重复 TypeError
- 封面缓存：以「路径 + 修改时间」派生磁盘文件名，命中则直接返回 URL，不重新拆包；清理缓存 会一并清掉

Fixes #41 Fixes #42 Fixes #44 Fixes #48 Fixes #18 Fixes #40 Fixes #43 Fixes #46 Fixes #47