### PR TITLE
fix: 将默认日志记录等级改为「信息」

### DIFF
--- a/cpp/LogManager.cpp
+++ b/cpp/LogManager.cpp
@@ -34,7 +34,7 @@ LogManager::LogManager(QObject *parent)
         const QString configPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation);
         QSettings settings(configPath + QStringLiteral("/BroNekoX/QueMusic.ini"), QSettings::IniFormat);
         m_enabled = settings.value(QStringLiteral("Options/logEnabled"), true).toBool();
-        m_minimumLevel = settings.value(QStringLiteral("Options/logLevel"), int(Level::Error)).toInt();
+        m_minimumLevel = settings.value(QStringLiteral("Options/logLevel"), int(Level::Info)).toInt();
         m_minimumLevel = qBound(int(Level::Debug), m_minimumLevel, int(Level::Fatal));
     }
 

--- a/cpp/LogManager.h
+++ b/cpp/LogManager.h
@@ -15,7 +15,7 @@
 // - 接管 Qt 全局消息（qDebug/qInfo/qWarning/qCritical/qFatal），同时保留控制台输出。
 // - 中文日志，写入“安装目录/logs/QueMusic_yyyyMMdd.log”（每日一个文件，UTF-8）。
 // - 多平台：安装目录不可写时回退到用户数据目录。
-// - 支持分级筛选（默认只记录“错误/致命”），默认开启。
+// - 支持分级筛选（默认记录“信息”及以上），默认开启。
 class LogManager : public QObject
 {
     Q_OBJECT
@@ -75,7 +75,7 @@ private:
     static std::atomic<LogManager *> s_instance;
 
     bool m_enabled = true;
-    int m_minimumLevel = Level::Error;   // 默认：错误（问题）
+    int m_minimumLevel = Level::Info;  // 默认：信息
     QString m_logDir;
     QString m_logFile;
     QString m_dateStamp;


### PR DESCRIPTION
将日志记录等级的默认值从「错误」改为「信息」。

- LogManager 初始等级改为 Level::Info
- 无历史配置的新用户默认记录 信息/警告/错误/致命
- 已有配置（Options/logLevel）仍按用户自己的选择生效

关联设置项：设置 → 日志 → 记录等级（调试 / 信息 / 警告 / 错误 / 致命）