### PR TITLE
fix: 按现有标签修正 Issue 模板打标

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,6 +1,6 @@
 name: "综合 Bug 反馈"
 description: "遇到的 Bug 不属于崩溃闪退，或其他未细分的 Bug"
-labels: [· Bug, 新提交]
+labels: [bug, 新提交]
 body:
 - type: checkboxes
   id: "check"

--- a/.github/ISSUE_TEMPLATE/crash.yml
+++ b/.github/ISSUE_TEMPLATE/crash.yml
@@ -1,6 +1,6 @@
 name: "崩溃 / 闪退反馈"
 description: "QueMusic 启动失败、运行中崩溃或闪退"
-labels: [· Bug, 新提交]
+labels: [bug, 新提交]
 body:
 - type: checkboxes
   id: "check"

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,6 +1,6 @@
 name: "新功能提案"
 description: "对已有功能的大幅度修改，或添加一个新内容或选项"
-labels: [· 新功能, 新提交]
+labels: [功能, 新提交]
 body:
 - type: checkboxes
   id: "check"

--- a/.github/ISSUE_TEMPLATE/optimize.yml
+++ b/.github/ISSUE_TEMPLATE/optimize.yml
@@ -1,6 +1,6 @@
 name: "优化建议"
 description: "对已有功能的小幅度优化或改进建议"
-labels: [· 优化, 新提交]
+labels: [功能, 新提交]
 body:
 - type: checkboxes
   id: "check"


### PR DESCRIPTION
之前合并的 Issue 模板里沿用了 PCL 的中文标签（· Bug、· 新功能、· 优化），但这些标签在 QueMusic 仓库里并不存在。现在按仓库当前已有的 label 修正：

| 模板 | 修正后自动标签 |
|---|---|
| ug.yml 综合 Bug 反馈 | ug + 新提交 |
| crash.yml 崩溃 / 闪退反馈 | ug + 新提交 |
| eature.yml 新功能提案 | 功能 + 新提交 |
| optimize.yml 优化建议 | 功能 + 新提交 |

说明：当前仓库没有「优化」标签，所以「优化建议」暂时和新功能一样挂 功能；若后续补了 优化 标签，可再把 optimize.yml 单独改过去。