### PR TITLE
调整底部播放栏的 封面、歌曲/歌手名 的交互逻辑

### DIFF
--- a/layout/PlayerControl.qml
+++ b/layout/PlayerControl.qml
@@ -188,12 +188,29 @@ Rectangle {
                 anchors.fill: parent
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
-                onClicked: {
-                    if(!window.musicTitle)  return;
-                    titleMenu.popup();
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
+                onClicked: (mouse) => {
+                    if (mouse.button === Qt.RightButton) {
+                        // 右键保留原有搜索菜单
+                        if(!window.musicTitle)  return;
+                        titleMenu.popup();
+                        return;
+                    }
+                    // 左键与控制栏整体点击行为一致——底部栏打开播放页，播放页点播放栏关闭
+                    if(mainLayout.state === "") {
+                        controlMaxLoader.active = true;
+                    } else {
+                        window.playermined();
+                        minedAnimation.start();
+                        mainLayout.state = "";
+                    }
+                }
+                QTip {
+                    visible: titleDisplayMouse.containsMouse
+                    text: "右键搜索"
                 }
             }
-            // 为防止误触，使用点击弹出菜单再搜索
+            // 右键弹出菜单再搜索，左键直接打开全屏播放器
             QMenu {
                 id: titleMenu
                 model: ["搜索歌曲名"]
@@ -222,16 +239,28 @@ Rectangle {
                 anchors.fill: parent
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
-                onClicked: {
-                    if(!window.musicArtist)  return; //本地音乐没有歌手信息时，忽略
-                    var artists = musicControlMin.parseArtists(window.musicArtist);
-                    artistMenu.model = artists;// 多歌手,弹菜单
-                    artistMenu.popup();
-
-                    //else {
-                    //    doSearchSongsMessage(artists[0]);// 单歌手直接搜
-                    //}
-
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
+                onClicked: (mouse) => {
+                    if (mouse.button === Qt.RightButton) {
+                        // 右键保留原有搜索菜单（多歌手选择）
+                        if(!window.musicArtist)  return; //本地音乐没有歌手信息时，忽略
+                        var artists = musicControlMin.parseArtists(window.musicArtist);
+                        artistMenu.model = artists;// 多歌手,弹菜单
+                        artistMenu.popup();
+                        return;
+                    }
+                    // 左键与控制栏整体点击行为一致：底部栏态打开播放页，播放页点同一位置关闭
+                    if(mainLayout.state === "") {
+                        controlMaxLoader.active = true;
+                    } else {
+                        window.playermined();
+                        minedAnimation.start();
+                        mainLayout.state = "";
+                    }
+                }
+                QTip {
+                    visible: artistDisplayMouse.containsMouse
+                    text: "右键搜索"
                 }
             }
             //多位歌手时，显示菜单

--- a/main.qml
+++ b/main.qml
@@ -640,6 +640,64 @@ Window {
                 maskThresholdMin: 0.5
                 maskSpreadAtMin: 1.0
             }
+            // 底部播放栏歌曲封面悬停提示：半透明遮罩 + 尖朝上的书名号
+            Rectangle {
+                z: 1
+                anchors.fill: musicpic
+                radius: musicpic.radius
+                color: "#000000"
+                opacity: (coverHover.containsMouse && mainLayout.state === "") ? 0.32 : 0
+                visible: opacity > 0
+                Behavior on opacity { NumberAnimation { duration: 160; easing.type: Easing.OutCubic } }
+            }
+            Canvas {
+                z: 1
+                width: 20
+                height: 15
+                anchors.centerIn: parent
+                opacity: (coverHover.containsMouse && mainLayout.state === "") ? 1 : 0
+                visible: opacity > 0
+                Behavior on opacity { NumberAnimation { duration: 160; easing.type: Easing.OutCubic } }
+                onPaint: {
+                    var ctx = getContext("2d");
+                    ctx.reset();
+                    ctx.strokeStyle = "#ffffff";
+                    ctx.lineWidth = 2;
+                    ctx.lineCap = "round";
+                    ctx.lineJoin = "round";
+                    // 尖朝上的书名号
+                    ctx.beginPath();
+                    ctx.moveTo(2, 7.5);
+                    ctx.lineTo(10, 1);
+                    ctx.lineTo(18, 7.5);
+                    ctx.stroke();
+                    ctx.beginPath();
+                    ctx.moveTo(2, 14);
+                    ctx.lineTo(10, 7.5);
+                    ctx.lineTo(18, 14);
+                    ctx.stroke();
+                }
+            }
+            // 左键点击底部播放栏封面直接打开全屏播放器
+            // 播放页封面（Maxed*，此时封面为大图）左键打开"查看图片"弹窗
+            MouseArea {
+                id: coverHover
+                z: 2
+                anchors.fill: musicpic
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onClicked: {
+                    if (mainLayout.state === "") {
+                        controlMaxLoader.active = true;
+                    } else {
+                        picWatch.dialog(mainMedia.urlStr || "qrc:/QueMusic/resources/app/musicpic.png", window.musicTitle);
+                    }
+                }
+                QTip {
+                    visible: coverHover.containsMouse && mainLayout.state === ""
+                    text: "进入播放页"
+                }
+            }
         }
 
         // 全窗口沉浸歌词页


### PR DESCRIPTION
- 相关issue：#15
- 调整内容：将左键点击底部播放栏的歌曲封面、歌手/歌曲名的效果改为进入播放页，只有右键才会弹出搜索菜单（鼠标悬浮会有提示）。